### PR TITLE
#48 Provide details of what differs when assert-same-values fails

### DIFF
--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/More Unit Tests/assert-throws-message.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/More Unit Tests/assert-throws-message.xqy
@@ -1,0 +1,56 @@
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare function local:case1()
+{
+  5 div 0
+};
+
+declare function local:case2()
+{
+  5 div 0
+};
+
+declare function local:case3()
+{
+  5 div 0
+};
+
+declare function local:case4()
+{
+  5 div 5
+};
+
+declare function local:case5($num)
+{
+  $num div 0
+};
+
+test:assert-throws-message(xdmp:function(xs:QName("local:case1"))),
+
+test:assert-throws-message(xdmp:function(xs:QName("local:case2")), "Division by zero"),
+
+try {
+  test:assert-throws-message(xdmp:function(xs:QName("local:case3")), "Division by zero 2"),
+  test:fail("Did not Throw error and should have")
+}
+catch($ex) {
+  if ($ex/error:name eq "ASSERT-THROWS-ERROR-FAILED") then
+    test:success()
+  else
+    test:fail($ex)
+},
+
+try {
+  test:assert-throws-message(xdmp:function(xs:QName("local:case4"))),
+  test:fail("Did not Throw error and should have")
+}
+catch($ex) {
+  if ($ex/error:name eq "ASSERT-THROWS-ERROR-FAILED") then
+    test:success()
+  else
+    test:fail($ex)
+},
+
+test:assert-throws-message(xdmp:function(xs:QName("local:case5")), 5, ()),
+
+test:assert-throws-message(xdmp:function(xs:QName("local:case5")), 5, "Division by zero")

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-message.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-message.xqy
@@ -1,0 +1,55 @@
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare function local:case1()
+{
+  test:assert-equal-message(<a class="1"/>, <g class="2"/>, "Case 1")
+};
+
+declare function local:case2()
+{
+  test:assert-equal-message((<a/>, <b/>, <c/>), (<a/>, <b/>), "Case 2")
+};
+
+declare function local:case3()
+{
+  test:assert-equal-message((<a/>, <b/>), (<a/>, <b/>, <c/>), "Case 3")
+};
+
+declare function local:case4()
+{
+  test:assert-equal-message((<a/>, <b/>, <c/>), (<a/>, <c/>, <b/>), "Case 4")
+};
+
+declare function local:case5()
+{
+  test:assert-equal-message((<a><aa/></a>, <b/>, <c/>), (element a { element aaa { } }, element b {}, element c {}), "Case 5")
+};
+
+test:assert-throws-error(xdmp:function(xs:QName("local:case1")), "ASSERT-EQUAL-FAILED"),
+test:assert-throws-message(xdmp:function(xs:QName("local:case1")), "Case 1"),
+
+test:assert-equal-message(<a class="1"/>, element a { attribute class { "1" } }, "Does not throw"),
+
+test:assert-throws-error(xdmp:function(xs:QName("local:case2")), "ASSERT-EQUAL-FAILED"),
+test:assert-throws-message(xdmp:function(xs:QName("local:case2")), "Case 2"),
+
+test:assert-throws-error(xdmp:function(xs:QName("local:case3")), "ASSERT-EQUAL-FAILED"),
+test:assert-throws-message(xdmp:function(xs:QName("local:case3")), "Case 3"),
+
+test:assert-throws-error(xdmp:function(xs:QName("local:case4")), "ASSERT-EQUAL-FAILED"),
+test:assert-throws-message(xdmp:function(xs:QName("local:case4")), "Case 4"),
+
+test:assert-equal((<a/>, <b/>, <c/>), (<a/>, <b/>, <c/>), "Does not throw"),
+
+test:assert-equal((<a/>, <b/>, <c/>), (element a {}, element b {}, element c {}), "Does not throw"),
+
+test:assert-equal((<a><aa/></a>, <b/>, <c/>), (element a { element aa { } }, element b {}, element c {}), "Does not throw"),
+
+test:assert-equal(5, 5, "Does not throw"),
+
+test:assert-equal("a", "a", "Does not throw"),
+
+test:assert-equal((), (), "Does not throw"),
+
+test:assert-throws-error(xdmp:function(xs:QName("local:case5")), "ASSERT-EQUAL-FAILED"),
+test:assert-throws-message(xdmp:function(xs:QName("local:case5")), "Case 5")

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-seq.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-seq.xqy
@@ -1,0 +1,42 @@
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare option xdmp:mapping "false";
+
+(: Same size sequences; all items match. :)
+
+test:assert-equal-seq((), ()),
+test:assert-equal-seq((1), (1)),
+test:assert-equal-seq((2, 4, 6, 8), (2, 4, 6, 8)),
+test:assert-equal-seq(("a", "bb", "c"), ("a", "bb", "c")),
+
+(: Same size sequences; item mismatch. :)
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1), (2)) },
+  "Item 1 differs. expected: 1, actual: 2"),
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1, 3, 6), (1, 3, 9)) },
+  "Item 3 differs. expected: 6, actual: 9"),
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq(("a", "bb", "c"), ("a", "bc", "c")) },
+  "Item 2 differs. expected: bb, actual: bc"),
+
+(: Different size sequences :)
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1, 2), (1, 3, 6)) },
+  "Item 2 differs. expected: 2, actual: 3"),
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1, 2), (1, 2, 3)) },
+  "Item count differs. expected: 2, actual: 3"),
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1, 2, 3), (1, 4)) },
+  "Item 2 differs. expected: 2, actual: 4"),
+
+test:assert-throws-message(
+  function () { test:assert-equal-seq((1, 2, 3), (1, 2)) },
+  "Item count differs. expected: 3, actual: 2")

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-same-values.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-same-values.xqy
@@ -1,0 +1,52 @@
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare option xdmp:mapping "false";
+
+(: Same size sequences; all items match; same order. :)
+
+test:assert-same-values((), ()),
+test:assert-same-values((1), (1)),
+test:assert-same-values((2, 4, 6, 8), (2, 4, 6, 8)),
+
+(: Same size sequences; all items match; different order. :)
+
+test:assert-same-values((2, 4, 6, 8), (4, 8, 6, 2)),
+test:assert-same-values(("bb", "c", "a"), ("a", "bb", "c")),
+
+(: Same size sequences; same order; item mismatch. :)
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1), (2)) },
+  "Item 1 differs. expected: 1, actual: 2"),
+
+test:assert-throws-message(
+  function () { test:assert-same-values((6, 3, 1), (3, 9, 1)) },
+  "Item 3 differs. expected: 6, actual: 9"),
+
+test:assert-throws-message(
+  function () { test:assert-same-values(("a", "bb", "c"), ("a", "bc", "c")) },
+  "Item 2 differs. expected: bb, actual: bc"),
+
+(: Same size sequences; different order; item mismatch. :)
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1, 3, 6), (1, 3, 9)) },
+  "Item 3 differs. expected: 6, actual: 9"),
+
+(: Different size sequences :)
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1, 2), (1, 3, 6)) },
+  "Item 2 differs. expected: 2, actual: 3"),
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1, 2), (1, 2, 3)) },
+  "Item count differs. expected: 2, actual: 3"),
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1, 2, 3), (1, 4)) },
+  "Item 2 differs. expected: 2, actual: 4"),
+
+test:assert-throws-message(
+  function () { test:assert-same-values((1, 2, 3), (1, 2)) },
+  "Item count differs. expected: 3, actual: 2")

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -244,6 +244,24 @@ declare function helper:assert-same-values($expected as item()*, $actual as item
   return helper:assert-equal($expected-ordered, $actual-ordered)
 };
 
+(: Return true if and only if the two sequences have the same values, dependent
+ : of order. If the sequences differ then report where they differ. :)
+declare function helper:assert-equal-seq($expected as item()*, $actual as item()*) {
+  let $expected-size := fn:count($expected)
+  let $actual-size := fn:count($actual)
+  return (
+    for $i in 1 to fn:min(($expected-size, $actual-size))
+    let $expected-i := $expected[$i]
+    let $actual-i := $actual[$i]
+    return helper:assert-equal-message(
+      $expected-i, $actual-i,
+      "Item " || $i || " differs. expected: " || $expected-i || ", actual: " || $actual-i),
+    helper:assert-equal-message(
+      $expected-size, $actual-size,
+      "Item count differs. expected: " || $expected-size || ", actual: " || $actual-size)
+  )
+};
+
 declare function helper:assert-equal($expected as item()*, $actual as item()*) {
   if (helper:are-these-equal($expected, $actual)) then
     helper:success()

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -541,6 +541,85 @@ declare private function helper:assert-throws-error_($function as xdmp:function,
     }
 };
 
+declare function helper:assert-throws-message($function as xdmp:function)
+{
+  helper:assert-throws-message_($function, json:to-array(), ())
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array(), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array( (json:to-array($param1), json:to-array('make me a sequence')), 1 ), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $param2 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array((json:to-array($param1), json:to-array($param2))), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3))), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3), json:to-array($param4))), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $param5 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3), json:to-array($param4), json:to-array($param5))), $error-message)
+};
+
+declare function helper:assert-throws-message($function as xdmp:function, $param1 as item()*, $param2 as item()*, $param3 as item()*, $param4 as item()*, $param5 as item()*, $param6 as item()*, $error-message as xs:string?)
+{
+  helper:assert-throws-message_($function, json:to-array((json:to-array($param1), json:to-array($param2), json:to-array($param3), json:to-array($param4), json:to-array($param5), json:to-array($param6))), $error-message)
+};
+
+declare private function helper:assert-throws-message_($function as xdmp:function, $params as json:array, $error-message as xs:string?)
+{
+  let $size := json:array-size($params)
+  return
+    try {
+      if ($size eq 0) then
+        xdmp:apply($function)
+      else if ($size eq 1) then
+        xdmp:apply($function, json:array-values($params[1]))
+      else if ($size eq 2) then
+          xdmp:apply($function, json:array-values($params[1]), json:array-values($params[2]))
+        else if ($size eq 3) then
+            xdmp:apply($function, json:array-values($params[1]), json:array-values($params[2]), json:array-values($params[3]))
+          else if ($size eq 4) then
+              xdmp:apply($function, json:array-values($params[1]), json:array-values($params[2]), json:array-values($params[3]), json:array-values($params[4]))
+            else if ($size eq 5) then
+                xdmp:apply($function, json:array-values($params[1]), json:array-values($params[2]), json:array-values($params[3]), json:array-values($params[4]), json:array-values($params[5]))
+              else if ($size eq 6) then
+                  xdmp:apply($function, json:array-values($params[1]), json:array-values($params[2]), json:array-values($params[3]), json:array-values($params[4]), json:array-values($params[5]), json:array-values($params[6]))
+                else (: arbitrary fall-back :)
+                  xdmp:apply($function, json:array-values($params))
+      ,
+      fn:error(xs:QName("ASSERT-THROWS-ERROR-FAILED"), "It did not throw an error")
+    }
+    catch($ex) {
+      if ($ex/error:name eq "ASSERT-THROWS-ERROR-FAILED") then
+        xdmp:rethrow()
+      else if ($error-message) then
+        if ($ex/error:message eq $error-message) then
+          helper:success()
+        else
+          (
+            fn:error(xs:QName("ASSERT-THROWS-ERROR-FAILED"), fn:concat("Error message was: ", $ex/error:message, " not: ", $error-message))
+          )
+      else
+        helper:success()
+    }
+};
+
 declare variable $local-url as xs:string := xdmp:get-request-protocol() || "://localhost:" || xdmp:get-request-port();
 declare variable $helper:DEFAULT_HTTP_OPTIONS := element xdmp-http:options {
   let $credential-id := xdmp:invoke-function(function() {

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -241,7 +241,7 @@ declare function helper:assert-same-values($expected as item()*, $actual as item
     for $a in $actual
     order by $a
     return $a
-  return helper:assert-equal($expected-ordered, $actual-ordered)
+  return helper:assert-equal-seq($expected-ordered, $actual-ordered)
 };
 
 (: Return true if and only if the two sequences have the same values, dependent

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -258,6 +258,20 @@ declare function helper:assert-equal($expected as item()*, $actual as item()*, $
     fn:error(xs:QName("ASSERT-EQUAL-FAILED"), "Assert Equal failed", ($expected, $actual, " : ", $error-object))
 };
 
+declare function helper:assert-equal-message($expected as item()*, $actual as item()*, $message as xs:string) {
+  if (helper:are-these-equal($expected, $actual)) then
+    helper:success()
+  else
+    fn:error(xs:QName("ASSERT-EQUAL-FAILED"), $message, ($expected, $actual))
+};
+
+declare function helper:assert-equal-message($expected as item()*, $actual as item()*, $message as xs:string, $error-object as item()*) {
+  if (helper:are-these-equal($expected, $actual)) then
+    helper:success()
+  else
+    fn:error(xs:QName("ASSERT-EQUAL-FAILED"), $message, ($expected, $actual, " : ", $error-object))
+};
+
 declare function helper:assert-not-equal($expected as item()*, $actual as item()*) {
   if (fn:not(helper:are-these-equal($expected, $actual))) then
     helper:success()


### PR DESCRIPTION
This adds various helper functions that are usefl in their own right to implement the functionality to provide details of what differs when `assert-same-values` fails, all of which have new test cases.