### PR TITLE
#46 Change test failure stack output from encoded XML to a nested text format

### DIFF
--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-controller.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-controller.xqy
@@ -274,10 +274,19 @@ declare function format-junit($result as element())
 					element failure {
 						attribute type {fn:data($result/error:error/error:name)},
 						attribute message {fn:data($result/error:error/error:message)},
-						xdmp:quote($result/error:error)
+						format-result($result/error:error, ())
 					}
 			}
 	}
+};
+
+declare private function format-result($result as element(), $tab as xs:string?) {
+  for $node in $result/*
+  let $tab := '&#9;' || $tab
+  return (
+    $tab || $node/fn:local-name() || ': ' || fn:normalize-space($node/text()) || '&#10;',
+    if ($node/*) then format-result($node, $tab) else ()
+  )
 };
 
 declare private function run-setup-or-teardown($setup as xs:boolean, $suite as xs:string)


### PR DESCRIPTION
Changed the test failure stack output so that rather than outputting fairly unreadable encoded XML, the new output will be nested text like the following:

name: ASSERT-EQUAL-FAILED
 	xquery-version: 1.0-ml
 	message: Assert Equal failed
 	format-string: Assert Equal failed (ASSERT-EQUAL-FAILED): You said: world You said: hello
 	retryable: false
 	expr: 
 	data: 
 		datum: You said: world
 		datum: You said: hello
 	stack: 
 		frame: 
 			uri: /test/test-helper.xqy
 			line: 486
 			column: 4
 			[...]

Exactly the same information will be output with each line having a label taken from the original XML error stack, but hopefully this is a bit easier to read.

In addition, I've created a ticket on the ml-gradle project (https://github.com/marklogic-community/ml-gradle/issues/430) to change the directory structure so that all test failures are output into a separate directory under marklogic-unit-test so that it is easier to work out which tests have failed without trawling through all the reports.