### PR TITLE
bintray config fixes

### DIFF
--- a/marklogic-junit/build.gradle
+++ b/marklogic-junit/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id "java"
 	id "maven-publish"
-	id "com.jfrog.bintray" version "1.8.0"
-	id "com.github.jk1.dependency-license-report" version "0.3.11"
+	id "com.jfrog.bintray" version "1.8.4"
+	id "com.github.jk1.dependency-license-report" version "1.3"
 	id "net.saliman.properties" version "1.4.6"
 }
 
@@ -66,8 +66,9 @@ if (project.hasProperty("myBintrayUser")) {
 		key = myBintrayKey
 		publications = ["mainJava", "sourcesJava"]
 		pkg {
-			repo = "maven"
+			repo = "Maven"
 			name = project.name
+      userOrg = 'marklogic-community'
 			licenses = ["Apache-2.0"]
 			vcsUrl = "https://github.com/marklogic-community/" + project.name + ".git"
 			version {

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -1,13 +1,13 @@
 plugins {
 	id "java"
 	id "maven-publish"
-	id "com.jfrog.bintray" version "1.8.0"
+	id "com.jfrog.bintray" version "1.8.4"
 
 	// ml-gradle is used for deploying a test application so that this project itself can be tested
 	id "com.marklogic.ml-gradle" version "3.7.1"
 
 	// Used to generate a license report
-	id "com.github.jk1.dependency-license-report" version "0.3.11"
+	id "com.github.jk1.dependency-license-report" version "1.3"
 }
 
 sourceCompatibility = "1.8"

--- a/marklogic-unit-test-modules/build.gradle
+++ b/marklogic-unit-test-modules/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "java"
   id "maven-publish"
-	id "com.jfrog.bintray" version "1.8.0"
+	id "com.jfrog.bintray" version "1.8.4"
 }
 
 // Defines a configuration for the MarkLogic modules; used by the modulesZip task below


### PR DESCRIPTION
I am running "gradle -i bintrayUpload" from the root project directory, and all 8 artifacts are published seemingly successfully, but the bintray plugin still throws an error. The notes on the 1.8.4 release imply that 1.8.4 fixes a bug regarding publishing something multiple times, but that appears to be the error. But, the packages still seem to be uploaded successfully.

Note that I seemingly need to run "bintrayUpload" from each subproject directory, as I'll get the error when running it from the root project before it uploads the artifacts for marklogic-unit-test-client and marklogic-unit-test-modules. 