### PR TITLE
Fixing Issue #44: assert-equal-json inconsistent in comparisons

### DIFF
--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-equal-json.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-equal-json.xqy
@@ -18,6 +18,7 @@ let $j3 := xdmp:to-json(xdmp:from-json-string(
   '{"PersonNameType":{"PersonGivenName":"LINDSEY", "PersonSurName":"JONES"},"charges":[1,true,"a",null]}'
 ))/node()
 
+
 let $j4 :=
   let $o := json:object()
   let $pnt := json:object()
@@ -46,6 +47,8 @@ let $j5 :=
   let $_ := map:put($o, "charges", $a)
   return $o
 
+let $j6 := xdmp:to-json(xdmp:from-json-string('{ "objKeyWithNullValue": null}'))/node()
+
 return xdmp:eager((
   test:assert-equal-json($j1, $j2),
   test:assert-equal-json($j1, $j3),
@@ -59,6 +62,6 @@ return xdmp:eager((
   }, "ASSERT-EQUAL-JSON-FAILED"),
   test:assert-throws-error(function() {
     test:assert-equal-json($j0, $j5)
-  }, "ASSERT-EQUAL-JSON-FAILED")
-
+  }, "ASSERT-EQUAL-JSON-FAILED"),
+  test:assert-equal-json($j6, $j6)
 ))

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -107,9 +107,9 @@ declare function test:load-test-file($filename as xs:string, $database-id as xs:
       xdmp:save($uri, test:get-test-file($filename))
   else
     let $doc := test:get-test-file($filename)
-    return 
+    return
       xdmp:invoke-function(
-        function() { 
+        function() {
           xdmp:document-insert($uri, $doc, $permissions, $collections)
         },
         <options xmlns="xdmp:eval">
@@ -637,7 +637,10 @@ declare function test:assert-equal-json-recursive($object1, $object2) as xs:bool
           test:assert-equal-json-recursive($v1, $v2)
       return $counts-equal and fn:not($maps-equal = fn:false())
     default return
-      $object1 = $object2
+      if(fn:empty($object1) and fn:empty($object2)) then
+        fn:true()
+      else
+        $object1 = $object2
 };
 
 declare function test:assert-true($supposed-truths as xs:boolean*) {


### PR DESCRIPTION
The issue occurred when comparing object nodes that had a key with a
null value. In assert-equal-json, the key value would be an empty
sequence. The empty sequences would get compared to each other
and return false.