### PR TITLE
Fixing Travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Attempting to fix the below error:

> Installing oraclejdk8
$ export JAVA_HOME=\~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ \~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.