### PR TITLE
apply $params in xdmp:xslt-invoke() for coverage report format transform

### DIFF
--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/default.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/default.xqy
@@ -54,7 +54,7 @@ declare function local:coverage-report()
 	let $params := map:new(( map:entry("test-dir", xdmp:get-request-field("/test/suites/")) ))
 	let $coverage-summary := coverage:summary($test-results/*)
 	return
-		xdmp:xslt-invoke("/test/xslt/coverage/report/" || $format || ".xsl", $coverage-summary)
+		xdmp:xslt-invoke("/test/xslt/coverage/report/" || $format || ".xsl", $coverage-summary, $params)
 };
 
 (:~


### PR DESCRIPTION
$params are currently unused. Shouldn't it be passed to the transform? Otherwise, we shouldn't even let the `$params` variable.