### PR TITLE
change hard-coded namespace-prefix test from name() to use self axis

### DIFF
--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/formats/j-unit.xsl
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/formats/j-unit.xsl
@@ -48,7 +48,7 @@
 		<xsl:text>&lt;</xsl:text>
 		<xsl:value-of select="name()"/>
 		<xsl:apply-templates select="@*" mode="serialize" />
-		<xsl:if test="name() = 'error:error'">
+		<xsl:if test="self::error:error">
 			<xsl:for-each select="namespace::*">
 				<xsl:text> </xsl:text>
 				<xsl:value-of select="name()"/>

--- a/src/main/ml-modules/root/test/formats/j-unit.xsl
+++ b/src/main/ml-modules/root/test/formats/j-unit.xsl
@@ -48,7 +48,7 @@
         <xsl:text>&lt;</xsl:text>
         <xsl:value-of select="name()"/>
         <xsl:apply-templates select="@*" mode="serialize" />
-        <xsl:if test="name() = 'error:error'">
+        <xsl:if test="self::error:error">
             <xsl:for-each select="namespace::*">
                 <xsl:text> </xsl:text>
                 <xsl:value-of select="name()"/>


### PR DESCRIPTION
`name()` will return the namespace-prefix of the instance XML document, which may not use "error". 

Changing to use the `self::` axis and use XPath to test if it is an `error:error` element.