### PR TITLE
Abstract mark logic test logger

### DIFF
--- a/marklogic-junit5/src/main/java/com/marklogic/junit5/AbstractMarkLogicTest.java
+++ b/marklogic-junit5/src/main/java/com/marklogic/junit5/AbstractMarkLogicTest.java
@@ -34,11 +34,6 @@ import java.util.List;
 public abstract class AbstractMarkLogicTest extends LoggingObject {
 
 	/**
-	 * A Logger is declared, as the SLF4J Logger API is brought in via the ml-javaclient-util dependency.
-	 */
-	protected final Logger logger = LoggerFactory.getLogger(getClass());
-
-	/**
 	 * Subclass must define how a connection is made to (presumably) the test database.
 	 *
 	 * @return

--- a/marklogic-junit5/src/main/java/com/marklogic/junit5/AbstractMarkLogicTest.java
+++ b/marklogic-junit5/src/main/java/com/marklogic/junit5/AbstractMarkLogicTest.java
@@ -14,8 +14,6 @@ import com.marklogic.test.unit.TestResult;
 import com.marklogic.test.unit.TestSuiteResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 


### PR DESCRIPTION
`AbstractMarkLogicTest extends LoggingObject`, which already declares the 

    protected final Logger logger = LoggerFactory.getLogger(getClass());

Remove duplicative declaration that shadows the existing `logger`.