### PR TITLE
Fixing #109: Rename assertions to LTE and GTE

### DIFF
--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-greater-than-or-equal.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-greater-than-or-equal.xqy
@@ -7,7 +7,7 @@ test:assert-throws-error-with-message(
     test:assert-greater-than-or-equal(2, 1)
   },
   "ASSERT-GREATER-THAN-OR-EQUAL-FAILED",
-  "actual: 1 is less than minimum: 2"
+  "actual: 1 is not greater than or equal to value: 2"
 ),
 
 test:assert-throws-error-with-message(
@@ -15,5 +15,5 @@ test:assert-throws-error-with-message(
     test:assert-greater-than-or-equal(2, (1, 2, 3), "Failure message")
   },
   "ASSERT-GREATER-THAN-OR-EQUAL-FAILED",
-  "Failure message; actual: (1, 2, 3) is less than minimum: 2"
+  "Failure message; actual: (1, 2, 3) is not greater than or equal to value: 2"
 )

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-greater-than-or-equal.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-greater-than-or-equal.xqy
@@ -1,0 +1,19 @@
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
+
+test:assert-greater-than-or-equal(2, 2),
+test:assert-greater-than-or-equal(2, (3, 4, 5, 6)),
+test:assert-throws-error-with-message(
+  function() {
+    test:assert-greater-than-or-equal(2, 1)
+  },
+  "ASSERT-GREATER-THAN-OR-EQUAL-FAILED",
+  "actual: 1 is less than minimum: 2"
+),
+
+test:assert-throws-error-with-message(
+  function() {
+    test:assert-greater-than-or-equal(2, (1, 2, 3), "Failure message")
+  },
+  "ASSERT-GREATER-THAN-OR-EQUAL-FAILED",
+  "Failure message; actual: (1, 2, 3) is less than minimum: 2"
+)

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-less-than-or-equal.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-less-than-or-equal.xqy
@@ -7,12 +7,12 @@ test:assert-throws-error-with-message(
     test:assert-less-than-or-equal(6, 7)
   },
   "ASSERT-LESS-THAN-OR-EQUAL-FAILED",
-  "actual: 7 is greater than maximum: 6"
+  "actual: 7 is not less than or equal to value: 6"
 ),
 test:assert-throws-error-with-message(
   function() {
     test:assert-less-than-or-equal(6, (5, 6, 7), "Failure message")
   },
   "ASSERT-LESS-THAN-OR-EQUAL-FAILED",
-  "Failure message; actual: (5, 6, 7) is greater than maximum: 6"
+  "Failure message; actual: (5, 6, 7) is not less than or equal to value: 6"
 )

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-less-than-or-equal.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-less-than-or-equal.xqy
@@ -1,0 +1,18 @@
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
+
+test:assert-less-than-or-equal(6, 6),
+test:assert-less-than-or-equal(6, (3, 4, 5, 6)),
+test:assert-throws-error-with-message(
+  function() {
+    test:assert-less-than-or-equal(6, 7)
+  },
+  "ASSERT-LESS-THAN-OR-EQUAL-FAILED",
+  "actual: 7 is greater than maximum: 6"
+),
+test:assert-throws-error-with-message(
+  function() {
+    test:assert-less-than-or-equal(6, (5, 6, 7), "Failure message")
+  },
+  "ASSERT-LESS-THAN-OR-EQUAL-FAILED",
+  "Failure message; actual: (5, 6, 7) is greater than maximum: 6"
+)

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -754,11 +754,70 @@ declare function test:assert-false($conditions as xs:boolean*, $message as xs:st
     test:success()
 };
 
+(: Deprecated.  Replaced by test:assert-greater-than-or-equal(). :)
 declare function test:assert-meets-minimum-threshold($minimum as xs:decimal, $actual as xs:decimal+) {
-  test:assert-meets-minimum-threshold($minimum, $actual, ())
+  (
+    test:assert-meets-minimum-threshold($minimum, $actual, ()),
+    xdmp:log("Assertion 'assert-meets-minimum-threshold()' has been deprecated.   Use 'assert-greater-than-or-equal()' instead.", "info")
+  )
 };
 
+(: Deprecated.  Replaced by test:assert-greater-than-or-equal(). :)
 declare function test:assert-meets-minimum-threshold(
+  $minimum as xs:decimal,
+  $actual as xs:decimal+,
+  $message as xs:string*
+) {
+  (
+    if (every $i in 1 to fn:count($actual) satisfies $actual[$i] ge $minimum) then
+      test:success()
+    else
+      let $message :=
+        fn:string-join((
+          $message,
+          "actual: " || xdmp:describe($actual) || " is less than minimum: " || xdmp:describe($minimum)
+        ), "; ")
+      return fn:error(xs:QName("ASSERT-MEETS-MINIMUM-THRESHOLD-FAILED"), $message, ($minimum, $actual))
+    ,
+    xdmp:log("Assertion 'assert-meets-minimum-threshold()' has been deprecated.   Use 'assert-greater-than-or-equal()' instead.", "info")
+  )
+};
+
+(: Deprecated.  Replaced by test:assert-less-than-or-equal(). :)
+declare function test:assert-meets-maximum-threshold($maximum as xs:decimal, $actual as xs:decimal+) {
+  (
+    test:assert-meets-maximum-threshold($maximum, $actual, ()),
+    xdmp:log("Assertion 'assert-meets-maximum-threshold()' has been deprecated.   Use 'assert-less-than-or-equal()' instead.", "info")
+  )
+};
+
+(: Deprecated.  Replaced by test:assert-less-than-or-equal(). :)
+declare function test:assert-meets-maximum-threshold(
+  $maximum as xs:decimal,
+  $actual as xs:decimal+,
+  $message as xs:string?
+) {
+  (
+    if (every $i in 1 to fn:count($actual) satisfies $actual[$i] le $maximum) then
+      test:success()
+    else
+      fn:error(
+        xs:QName("ASSERT-MEETS-MAXIMUM-THRESHOLD-FAILED"),
+        fn:string-join((
+          $message,
+          "actual: " || xdmp:describe($actual) || " is greater than maximum: " || xdmp:describe($maximum)
+        ), "; "),
+        ($maximum, $actual))
+    ,
+    xdmp:log("Assertion 'assert-meets-maximum-threshold()' has been deprecated.   Use 'assert-less-than-or-equal()' instead.", "info")
+  )
+};
+
+declare function test:assert-greater-than-or-equal($minimum as xs:decimal, $actual as xs:decimal+) {
+  test:assert-greater-than-or-equal($minimum, $actual, ())
+};
+
+declare function test:assert-greater-than-or-equal(
   $minimum as xs:decimal,
   $actual as xs:decimal+,
   $message as xs:string*
@@ -771,14 +830,14 @@ declare function test:assert-meets-minimum-threshold(
         $message,
         "actual: " || xdmp:describe($actual) || " is less than minimum: " || xdmp:describe($minimum)
       ), "; ")
-    return fn:error(xs:QName("ASSERT-MEETS-MINIMUM-THRESHOLD-FAILED"), $message, ($minimum, $actual))
+    return fn:error(xs:QName("ASSERT-GREATER-THAN-OR-EQUAL-FAILED"), $message, ($minimum, $actual))
 };
 
-declare function test:assert-meets-maximum-threshold($maximum as xs:decimal, $actual as xs:decimal+) {
-  test:assert-meets-maximum-threshold($maximum, $actual, ())
+declare function test:assert-less-than-or-equal($maximum as xs:decimal, $actual as xs:decimal+) {
+  test:assert-less-than-or-equal($maximum, $actual, ())
 };
 
-declare function test:assert-meets-maximum-threshold(
+declare function test:assert-less-than-or-equal(
   $maximum as xs:decimal,
   $actual as xs:decimal+,
   $message as xs:string?
@@ -787,7 +846,7 @@ declare function test:assert-meets-maximum-threshold(
     test:success()
   else
     fn:error(
-      xs:QName("ASSERT-MEETS-MAXIMUM-THRESHOLD-FAILED"),
+      xs:QName("ASSERT-LESS-THAN-OR-EQUAL-FAILED"),
       fn:string-join((
         $message,
         "actual: " || xdmp:describe($actual) || " is greater than maximum: " || xdmp:describe($maximum)

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -818,19 +818,19 @@ declare function test:assert-greater-than-or-equal($minimum as xs:decimal, $actu
 };
 
 declare function test:assert-greater-than-or-equal(
-  $minimum as xs:decimal,
+  $value as xs:decimal,
   $actual as xs:decimal+,
   $message as xs:string*
 ) {
-  if (every $i in 1 to fn:count($actual) satisfies $actual[$i] ge $minimum) then
+  if (every $i in 1 to fn:count($actual) satisfies $actual[$i] ge $value) then
     test:success()
   else
     let $message :=
       fn:string-join((
         $message,
-        "actual: " || xdmp:describe($actual) || " is less than minimum: " || xdmp:describe($minimum)
+        "actual: " || xdmp:describe($actual) || " is not greater than or equal to value: " || xdmp:describe($value)
       ), "; ")
-    return fn:error(xs:QName("ASSERT-GREATER-THAN-OR-EQUAL-FAILED"), $message, ($minimum, $actual))
+    return fn:error(xs:QName("ASSERT-GREATER-THAN-OR-EQUAL-FAILED"), $message, ($value, $actual))
 };
 
 declare function test:assert-less-than-or-equal($maximum as xs:decimal, $actual as xs:decimal+) {
@@ -838,20 +838,20 @@ declare function test:assert-less-than-or-equal($maximum as xs:decimal, $actual 
 };
 
 declare function test:assert-less-than-or-equal(
-  $maximum as xs:decimal,
+  $value as xs:decimal,
   $actual as xs:decimal+,
   $message as xs:string?
 ) {
-  if (every $i in 1 to fn:count($actual) satisfies $actual[$i] le $maximum) then
+  if (every $i in 1 to fn:count($actual) satisfies $actual[$i] le $value) then
     test:success()
   else
     fn:error(
       xs:QName("ASSERT-LESS-THAN-OR-EQUAL-FAILED"),
       fn:string-join((
         $message,
-        "actual: " || xdmp:describe($actual) || " is greater than maximum: " || xdmp:describe($maximum)
+        "actual: " || xdmp:describe($actual) || " is not less than or equal to value: " || xdmp:describe($value)
       ), "; "),
-      ($maximum, $actual))
+      ($value, $actual))
 };
 
 declare function test:assert-throws-error-with-message($function as xdmp:function, $expected-error-code as xs:string, $expected-message as xs:string) {


### PR DESCRIPTION
Renamed the assert-meets-minimum-threshold() assertion function to
assert-greater-than-or-equal().

Renamed the assert-meets-maximum-threshold() assertion function to
assert-less-than-or-equal().

Left old functions for backwards compatibility. Added Info log
messages about deprecated functions when old ones are used.