### PR TITLE
Updating multiple dependencies to take care of the Spring vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "com.marklogic:marklogic-unit-test-client:1.1.0"
+    classpath "com.marklogic:marklogic-unit-test-client:1.2.0"
     classpath "com.marklogic:ml-gradle:4.2.1"
   }
 }
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-  mlBundle "com.marklogic:marklogic-unit-test-modules:1.1.0"
+  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
   apply plugin: "signing"
 
   group = "com.marklogic"
-  version = "1.1.0"
+  version = "1.2.0"
 
   sourceCompatibility = "8"
   targetCompatibility = "8"

--- a/marklogic-junit5/build.gradle
+++ b/marklogic-junit5/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 dependencies {
   api project(":marklogic-unit-test-client")
-  api "com.marklogic:ml-javaclient-util:4.3.0"
+  api "com.marklogic:ml-javaclient-util:4.3.1"
   api "org.jdom:jdom2:2.0.6"
   api "org.junit.jupiter:junit-jupiter:5.7.2"
-  api "org.springframework:spring-context:5.3.9"
-  api "org.springframework:spring-test:5.3.9"
+  api "org.springframework:spring-context:5.3.18"
+  api "org.springframework:spring-test:5.3.18"
   api "com.fasterxml.jackson.core:jackson-databind:2.11.1"
   api "org.slf4j:slf4j-api:1.7.31"
 

--- a/marklogic-junit5/examples/simple-ml-gradle/README.md
+++ b/marklogic-junit5/examples/simple-ml-gradle/README.md
@@ -36,7 +36,7 @@ Next, add the following dependencies:
     dependencies {
       // existing dependencies
       
-      testImplementation "com.marklogic:marklogic-junit5:1.1.0"
+      testImplementation "com.marklogic:marklogic-junit5:1.2.0"
             
       testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
     
@@ -110,8 +110,8 @@ You'll still be able to leverage all of the testing support in AbstractMarkLogic
 If you'd like to write and execute marklogic-unit-test test modules, add the following to your build.gradle file as well (grab
 the latest version for both dependencies):
 
-    mlBundle "com.marklogic:marklogic-unit-test-modules:1.1.0"
-    testImplementation "com.marklogic:marklogic-unit-test-client:1.1.0"
+    mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
+    testImplementation "com.marklogic:marklogic-unit-test-client:1.2.0"
 
 In addition, add the following to gradle.properties so that you can store test modules in a directory separate from 
 your application modules:

--- a/marklogic-junit5/examples/simple-ml-gradle/build.gradle
+++ b/marklogic-junit5/examples/simple-ml-gradle/build.gradle
@@ -14,11 +14,11 @@ repositories {
 }
 
 dependencies {
-  mlBundle "com.marklogic:marklogic-unit-test-modules:1.1.0"
+  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
 
 	api "com.marklogic:marklogic-client-api:5.5.3"
 
-	testImplementation "com.marklogic:marklogic-junit5:1.1.0"
+	testImplementation "com.marklogic:marklogic-junit5:1.2.0"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
 

--- a/marklogic-junit5/examples/simple-ml-gradle/build.gradle
+++ b/marklogic-junit5/examples/simple-ml-gradle/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
   mlBundle "com.marklogic:marklogic-unit-test-modules:1.1.0"
 
-	api "com.marklogic:marklogic-client-api:5.5.0"
+	api "com.marklogic:marklogic-client-api:5.5.3"
 
 	testImplementation "com.marklogic:marklogic-junit5:1.1.0"
 

--- a/marklogic-junit5/pom.xml
+++ b/marklogic-junit5/pom.xml
@@ -46,7 +46,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
-      <version>4.3.0</version>
+      <version>4.3.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -64,13 +64,13 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.18</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.18</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/marklogic-junit5/pom.xml
+++ b/marklogic-junit5/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-junit5</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <name>com.marklogic:marklogic-junit5</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-junit5</url>
@@ -40,7 +40,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-unit-test-client</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-	api "com.marklogic:marklogic-client-api:5.5.0"
+	api "com.marklogic:marklogic-client-api:5.5.3"
   implementation "org.slf4j:slf4j-api:1.7.31"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"

--- a/marklogic-unit-test-client/pom.xml
+++ b/marklogic-unit-test-client/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-unit-test-client</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <name>com.marklogic:marklogic-unit-test-client</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-unit-test-client</url>

--- a/marklogic-unit-test-client/pom.xml
+++ b/marklogic-unit-test-client/pom.xml
@@ -40,7 +40,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-client-api</artifactId>
-      <version>5.5.0</version>
+      <version>5.5.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
-  org.springframework:spring-context:5.3.9->5.3.18
- org.springframework:spring-test:5.3.9->5.3.18
- ml-javaclient-util:4.3.0->4.3.1
- marklogic-client-api:5.5.0->5.5.3

Bumping the version to 1.2.0