### PR TITLE
Upgrading dependencies and bumped to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "com.marklogic:marklogic-unit-test-client:1.2.0"
-    classpath "com.marklogic:ml-gradle:4.2.1"
+    classpath "com.marklogic:marklogic-unit-test-client:1.2.1"
+    classpath "com.marklogic:ml-gradle:4.3.5"
   }
 }
 
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
+  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.1"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,12 @@ subprojects {
   apply plugin: "signing"
 
   group = "com.marklogic"
-  version = "1.2.0"
+  version = "1.2.1"
 
-  sourceCompatibility = "8"
-  targetCompatibility = "8"
+  java {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
 
   repositories {
     mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-# Using 6.9 until ml-gradle 4.3 is available, which will support 7.x
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/marklogic-junit5/build.gradle
+++ b/marklogic-junit5/build.gradle
@@ -4,22 +4,22 @@ plugins {
 
 dependencies {
   api project(":marklogic-unit-test-client")
-  api "com.marklogic:ml-javaclient-util:4.3.1"
-  api "org.jdom:jdom2:2.0.6"
-  api "org.junit.jupiter:junit-jupiter:5.7.2"
-  api "org.springframework:spring-context:5.3.18"
-  api "org.springframework:spring-test:5.3.18"
-  api "com.fasterxml.jackson.core:jackson-databind:2.11.1"
-  api "org.slf4j:slf4j-api:1.7.31"
+  api "com.marklogic:ml-javaclient-util:4.3.3"
+  api "org.jdom:jdom2:2.0.6.1"
+  api "org.junit.jupiter:junit-jupiter:5.9.0"
+  api "org.springframework:spring-context:5.3.22"
+  api "org.springframework:spring-test:5.3.22"
+  api "com.fasterxml.jackson.core:jackson-databind:2.12.6.1"
+  api 'org.slf4j:slf4j-api:1.7.36'
 
   implementation "jaxen:jaxen:1.2.0"
 
-  testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
 
 	// Forcing Spring to use logback instead of commons-logging
-  testImplementation "ch.qos.logback:logback-classic:1.2.4"
-  testImplementation "org.slf4j:jcl-over-slf4j:1.7.31"
-  testImplementation "org.slf4j:slf4j-api:1.7.31"
+  testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+  testImplementation 'org.slf4j:jcl-over-slf4j:1.7.36'
+  testImplementation 'org.slf4j:slf4j-api:1.7.36'
 }
 
 test {

--- a/marklogic-junit5/examples/simple-ml-gradle/README.md
+++ b/marklogic-junit5/examples/simple-ml-gradle/README.md
@@ -36,14 +36,11 @@ Next, add the following dependencies:
     dependencies {
       // existing dependencies
       
-      testImplementation "com.marklogic:marklogic-junit5:1.2.0"
+      testImplementation "com.marklogic:marklogic-junit5:1.2.1"
             
-      testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
-    
       // Forcing Spring to use logback instead of commons-logging
-      testImplementation "ch.qos.logback:logback-classic:1.2.4"
-      testImplementation "org.slf4j:jcl-over-slf4j:1.7.31"
-      testImplementation "org.slf4j:slf4j-api:1.7.31"
+      testImplementation "ch.qos.logback:logback-classic:1.2.11"
+      testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
     }
     
 ### Configure gradle.properties
@@ -110,8 +107,8 @@ You'll still be able to leverage all of the testing support in AbstractMarkLogic
 If you'd like to write and execute marklogic-unit-test test modules, add the following to your build.gradle file as well (grab
 the latest version for both dependencies):
 
-    mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
-    testImplementation "com.marklogic:marklogic-unit-test-client:1.2.0"
+    mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.1"
+    testImplementation "com.marklogic:marklogic-unit-test-client:1.2.1"
 
 In addition, add the following to gradle.properties so that you can store test modules in a directory separate from 
 your application modules:

--- a/marklogic-junit5/examples/simple-ml-gradle/build.gradle
+++ b/marklogic-junit5/examples/simple-ml-gradle/build.gradle
@@ -14,16 +14,13 @@ repositories {
 }
 
 dependencies {
-  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.0"
+  mlBundle "com.marklogic:marklogic-unit-test-modules:1.2.1"
 
 	api "com.marklogic:marklogic-client-api:5.5.3"
 
-	testImplementation "com.marklogic:marklogic-junit5:1.2.0"
-
-  testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
+	testImplementation "com.marklogic:marklogic-junit5:1.2.1"
 
 	// Forcing Spring to use logback instead of commons-logging
-  testImplementation "ch.qos.logback:logback-classic:1.2.4"
-  testImplementation "org.slf4j:jcl-over-slf4j:1.7.31"
-  testImplementation "org.slf4j:slf4j-api:1.7.31"
+  testImplementation "ch.qos.logback:logback-classic:1.2.12"
+  testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
 }

--- a/marklogic-junit5/pom.xml
+++ b/marklogic-junit5/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-junit5</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>com.marklogic:marklogic-junit5</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-junit5</url>
@@ -40,37 +40,37 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-unit-test-client</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
-      <version>4.3.1</version>
+      <version>4.3.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.6.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.7.2</version>
+      <version>5.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.18</version>
+      <version>5.3.22</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.3.18</version>
+      <version>5.3.22</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.31</version>
+      <version>1.7.36</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	// ml-gradle is used for deploying a test application so that this project itself can be tested
-	id "com.marklogic.ml-gradle" version "4.2.1"
+	id "com.marklogic.ml-gradle" version "4.3.5"
 
 	// Used to generate a license report
 	id "com.github.jk1.dependency-license-report" version "1.17"
@@ -8,9 +8,9 @@ plugins {
 
 dependencies {
 	api "com.marklogic:marklogic-client-api:5.5.3"
-  implementation "org.slf4j:slf4j-api:1.7.31"
+  implementation "org.slf4j:slf4j-api:1.7.36"
 
-  testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
+  testImplementation "org.junit.jupiter:junit-jupiter:5.9.0"
 }
 
 test {

--- a/marklogic-unit-test-client/pom.xml
+++ b/marklogic-unit-test-client/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-unit-test-client</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>com.marklogic:marklogic-unit-test-client</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-unit-test-client</url>
@@ -46,7 +46,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.31</version>
+      <version>1.7.36</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
I'm looking to do a 1.2.1 release that only upgrades dependencies so that they're in sync with the ml-gradle stack. The driving use case is I want to start using marklogic-junit5 for tests in the Kafka connector project and I'd like to have the same versions of all Java Client / Spring / etc dependencies. 