### PR TITLE
#152 Bumped Java Client to 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
   apply plugin: "signing"
 
   group = "com.marklogic"
-  version = "1.2.1"
+  version = "1.3.0-SNAPSHOT"
 
   java {
     sourceCompatibility = 1.8
@@ -16,6 +16,13 @@ subprojects {
 
     // For local development
     mavenLocal()
+  }
+
+  dependencies {
+    // Forcing Spring to use logback instead of commons-logging
+    testImplementation "ch.qos.logback:logback-classic:1.3.5" // Not using 1.4.x yet as it requires Java 11
+    testImplementation 'org.slf4j:jcl-over-slf4j:1.7.36'
+    testImplementation 'org.slf4j:slf4j-api:1.7.36'
   }
 
   javadoc.failOnError = false

--- a/marklogic-junit5/build.gradle
+++ b/marklogic-junit5/build.gradle
@@ -4,22 +4,15 @@ plugins {
 
 dependencies {
   api project(":marklogic-unit-test-client")
-  api "com.marklogic:ml-javaclient-util:4.3.3"
+  api "com.marklogic:ml-javaclient-util:4.3.7"   // TODO Upgrade this to 4.4.0 once it's available
   api "org.jdom:jdom2:2.0.6.1"
-  api "org.junit.jupiter:junit-jupiter:5.9.0"
-  api "org.springframework:spring-context:5.3.22"
-  api "org.springframework:spring-test:5.3.22"
-  api "com.fasterxml.jackson.core:jackson-databind:2.12.6.1"
+  api "org.junit.jupiter:junit-jupiter:5.9.1"
+  api "org.springframework:spring-context:5.3.24"
+  api "org.springframework:spring-test:5.3.24"
+  api "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
   api 'org.slf4j:slf4j-api:1.7.36'
 
-  implementation "jaxen:jaxen:1.2.0"
-
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
-
-	// Forcing Spring to use logback instead of commons-logging
-  testImplementation 'ch.qos.logback:logback-classic:1.2.11'
-  testImplementation 'org.slf4j:jcl-over-slf4j:1.7.36'
-  testImplementation 'org.slf4j:slf4j-api:1.7.36'
+  implementation "jaxen:jaxen:2.0.0"
 }
 
 test {

--- a/marklogic-junit5/pom.xml
+++ b/marklogic-junit5/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-junit5</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
   <name>com.marklogic:marklogic-junit5</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-junit5</url>
@@ -40,13 +40,13 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-unit-test-client</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
-      <version>4.3.3</version>
+      <version>4.3.7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -58,25 +58,25 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.9.0</version>
+      <version>5.9.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.24</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.24</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.13.4.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -88,7 +88,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.2.0</version>
+      <version>2.0.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -1,16 +1,16 @@
 plugins {
 	// ml-gradle is used for deploying a test application so that this project itself can be tested
-	id "com.marklogic.ml-gradle" version "4.3.5"
+	id "com.marklogic.ml-gradle" version "4.3.7"
 
 	// Used to generate a license report
 	id "com.github.jk1.dependency-license-report" version "1.17"
 }
 
 dependencies {
-	api "com.marklogic:marklogic-client-api:5.5.3"
+	api "com.marklogic:marklogic-client-api:6.0.0"
   implementation "org.slf4j:slf4j-api:1.7.36"
 
-  testImplementation "org.junit.jupiter:junit-jupiter:5.9.0"
+  testImplementation "org.junit.jupiter:junit-jupiter:5.9.1"
 }
 
 test {

--- a/marklogic-unit-test-client/pom.xml
+++ b/marklogic-unit-test-client/pom.xml
@@ -12,7 +12,7 @@ It is not intended to be used to build this project.
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-unit-test-client</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
   <name>com.marklogic:marklogic-unit-test-client</name>
   <description>Supports testing MarkLogic applications</description>
   <url>https://github.com/marklogic-community/marklogic-unit-test-client</url>
@@ -40,7 +40,7 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-client-api</artifactId>
-      <version>5.5.3</version>
+      <version>6.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/marklogic-unit-test-client/src/test/resources/logback.xml
+++ b/marklogic-unit-test-client/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+	<logger name="ch.qos.logback" level="WARN" additivity="false"/>
+	<logger name="com.marklogic.client" level="WARN" additivity="false"/>
+</configuration>


### PR DESCRIPTION
Bumped a few other dependencies; jaxen is now 2.0.0 and according to the release notes is a drop-in replacement, despite the major version change. 

Note that the pom.xml files are not used for building the software but only to power Github's Dependency Graph feature. 