### PR TITLE
154 Removing Roxy references

### DIFF
--- a/docs/loading-data/index.html
+++ b/docs/loading-data/index.html
@@ -191,8 +191,6 @@
         <div class="col-md-9">
           <h2 id="loading-data">Loading Data</h2>
 
-<p><em>TODO: replace Roxy content with marklogic-unit-test</em></p>
-
 <p>MarkLogic Unit Test simplifies loading data for your tests. Files to be loaded can be placed in a sub-directory of your test suite called <code class="highlighter-rouge">test-data</code>. The test helper provides a function which will automatically use this directory as the location of test files to be loaded.</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>test:load-data-file(&lt;name-of-file-to-be-loaded-without-path&gt;,database id, &lt;URI&gt;)
@@ -209,7 +207,7 @@ setup script could look like this in JavaScript:</p>
 
 <p>… and in XQuery:</p>
 
-<div class="language-xquery highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">test</span> <span class="o">=</span> <span class="s2">"http://marklogic.com/roxy/test-helper"</span> <span class="k">at</span> <span class="s2">"/test/test-helper.xqy"</span><span class="p">;</span>
+<div class="language-xquery highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">test</span> <span class="o">=</span> <span class="s2">"http://marklogic.com/test-helper"</span> <span class="k">at</span> <span class="s2">"/test/test-helper.xqy"</span><span class="p">;</span>
 <span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">lib</span> <span class="o">=</span> <span class="s2">"http://example.com/test/lib"</span> <span class="k">at</span> <span class="s2">"lib/lib.xqy"</span><span class="p">;</span>
 
 <span class="nf">test:load-test-file</span><span class="p">(</span><span class="s2">"test-article.xml"</span><span class="p">,</span> <span class="nf">xdmp:database</span><span class="p">(),</span> <span class="nv">$</span><span class="n">lib:URI</span><span class="p">)</span>

--- a/docs/testing-with-xquery/index.html
+++ b/docs/testing-with-xquery/index.html
@@ -1,211 +1,264 @@
-<!doctype html>
-<!--[if lt IE 7 ]><html itemscope itemtype="http://schema.org/Organization" id="ie6" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 7 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie7" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 8 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie8" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 9 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie9" class="ie" lang="en-US"><![endif]-->
-<!--[if gt IE 9]><!--><html itemscope itemtype="http://schema.org/Organization" lang="en-US"><!--<![endif]-->
-<head>
-
+<!DOCTYPE html>
+<!--[if lt IE 7]><html itemscope itemtype="http://schema.org/Organization" id="ie6" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 7]>   <html itemscope itemtype="http://schema.org/Organization" id="ie7" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 8]>   <html itemscope itemtype="http://schema.org/Organization" id="ie8" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 9]>   <html itemscope itemtype="http://schema.org/Organization" id="ie9" class="ie" lang="en-US"><![endif]-->
+<!--[if gt IE 9]><!--><html
+  itemscope
+  itemtype="http://schema.org/Organization"
+  lang="en-US"
+><!--<![endif]-->
+  <head>
     <!-- Meta -->
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Testing With XQuery - MarkLogic Unit Test</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <meta content="yes" name="apple-mobile-web-app-capable">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
+    <meta content="yes" name="apple-mobile-web-app-capable" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
 
     <!-- Favicons -->
-    <link rel="shortcut icon" sizes="16x16 24x24 32x32 48x48 64x64 96x96" href="/marklogic-unit-test/favicon.ico">
-    <meta name="application-name" content="MarkLogic Unit Test - A Unit Test framework for MarkLogic">
+    <link
+      rel="shortcut icon"
+      sizes="16x16 24x24 32x32 48x48 64x64 96x96"
+      href="/marklogic-unit-test/favicon.ico"
+    />
+    <meta
+      name="application-name"
+      content="MarkLogic Unit Test - A Unit Test framework for MarkLogic"
+    />
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
+      );
 
-      ga('create', 'UA-6638631-15', 'auto');
-      ga('send', 'pageview');
-
+      ga("create", "UA-6638631-15", "auto");
+      ga("send", "pageview");
     </script>
 
     <!-- Facebook Pixel Code -->
     <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '1879746318909687'); // Insert your pixel ID here.
-    fbq('track', 'PageView');
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod
+            ? n.callMethod.apply(n, arguments)
+            : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = "2.0";
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        "script",
+        "https://connect.facebook.net/en_US/fbevents.js"
+      );
+      fbq("init", "1879746318909687"); // Insert your pixel ID here.
+      fbq("track", "PageView");
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=1879746318909687&ev=PageView&noscript=1"
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=1879746318909687&ev=PageView&noscript=1"
     /></noscript>
     <!-- DO NOT MODIFY -->
     <!-- End Facebook Pixel Code -->
-    <link type="text/css" rel="stylesheet" href="/marklogic-unit-test/assets/bundle.css">
-</head>
-<body class="">
-
+    <link
+      type="text/css"
+      rel="stylesheet"
+      href="/marklogic-unit-test/assets/bundle.css"
+    />
+  </head>
+  <body class="">
     <nav class="navbar navbar-inverse">
-        <div class="container-fluid">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-                <a class="navbar-brand" href="/marklogic-unit-test">
-                  <span class="logo">
-                    <img src="/marklogic-unit-test/images/logo-marklogic.svg" width="180px" height="38px" alt="MarkLogic" title="MarkLogic" scale="0">
-                  </span>
-                  MarkLogic Unit Test
-                </a>
-            </div>
-            <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-right">
-                    
-                        <li  >
-                            
-                            <a href="/marklogic-unit-test/">Getting Started</a>
-                            
-                        </li>
-                    
-                        <li  >
-                            
-                            <a href="https://github.com/marklogic-community/marklogic-unit-test">GitHub</a>
-                            
-                        </li>
-                    
-                </ul>
-            </div>
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#navbar"
+            aria-expanded="false"
+            aria-controls="navbar"
+          >
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/marklogic-unit-test">
+            <span class="logo">
+              <img
+                src="/marklogic-unit-test/images/logo-marklogic.svg"
+                width="180px"
+                height="38px"
+                alt="MarkLogic"
+                title="MarkLogic"
+                scale="0"
+              />
+            </span>
+            MarkLogic Unit Test
+          </a>
         </div>
+        <div id="navbar" class="navbar-collapse collapse">
+          <ul class="nav navbar-nav navbar-right">
+            <li>
+              <a href="/marklogic-unit-test/">Getting Started</a>
+            </li>
+
+            <li>
+              <a
+                href="https://github.com/marklogic-community/marklogic-unit-test"
+                >GitHub</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
     </nav>
 
+    <article>
+      <div class="container">
+        <div class="row">
+          <div class="side-nav col-md-3 hide-small">
+            <div class="panel panel-default">
+              <div class="panel-heading">Navigation</div>
+              <ul class="list-group">
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/">Getting Started</a>
+                </li>
 
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/include/"
+                    >How to Include MarkLogic Unit Test in Your Project</a
+                  >
+                </li>
 
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/running/"
+                    >How to Run Your Tests</a
+                  >
+                </li>
 
-  <article>
-    <div class="container">
-      <div class="row">
-        <div class="side-nav col-md-3 hide-small">
-          <div class="panel panel-default">
-  <div class="panel-heading">Navigation</div>
-  <ul class="list-group">
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/">Getting Started</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/include/">How to Include MarkLogic Unit Test in Your Project</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/running/">How to Run Your Tests</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/">Docs</a>
-    
-    
-      <ul class="list-group">
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/conventions/">Filename Conventions</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/loading-data/">Loading Data</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/testing-with-sjs/">Testing With JavaScript</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item active"  >
-    
-    <a href="/marklogic-unit-test/docs/testing-with-xquery/">Testing With XQuery</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/assertions/">Assert Functions</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/transactional/">Transactional Unit Tests</a>
-    
-    
-  </li>
-  
-</ul>
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/docs/">Docs</a>
 
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/good-tests/">Guidelines for Writing Good Tests</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="https://github.com/marklogic-community/marklogic-unit-test">MarkLogic Unit Test on GitHub</a>
-    
-    
-  </li>
-  
-</ul>
+                  <ul class="list-group">
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/conventions/"
+                        >Filename Conventions</a
+                      >
+                    </li>
 
-</div>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/loading-data/"
+                        >Loading Data</a
+                      >
+                    </li>
 
-        </div>
-        <div class="col-md-9">
-          <h1 id="testing-with-xquery">Testing With XQuery</h1>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/testing-with-sjs/"
+                        >Testing With JavaScript</a
+                      >
+                    </li>
 
-<p><em>TODO</em></p>
+                    <li class="list-group-item active">
+                      <a href="/marklogic-unit-test/docs/testing-with-xquery/"
+                        >Testing With XQuery</a
+                      >
+                    </li>
 
-<h2 id="testing-xquery-with-xquery">Testing XQuery With XQuery</h2>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/assertions/"
+                        >Assert Functions</a
+                      >
+                    </li>
 
-<p><em>TODO</em></p>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/transactional/"
+                        >Transactional Unit Tests</a
+                      >
+                    </li>
+                  </ul>
+                </li>
 
-<h2 id="test-server-side-javascript-with-xquery">Test Server-side JavaScript with XQuery</h2>
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/good-tests/"
+                    >Guidelines for Writing Good Tests</a
+                  >
+                </li>
 
-<p><em>TODO: is this information current?</em></p>
+                <li class="list-group-item">
+                  <a
+                    href="https://github.com/marklogic-community/marklogic-unit-test"
+                    >MarkLogic Unit Test on GitHub</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-9">
+            <h1 id="testing-with-xquery">Testing With XQuery</h1>
 
-<p>You can write unit tests in XQuery to test code written in JavaScript. The one tricky part is that you can’t import an .sjs module (such as the code you want to test) in XQuery. You can use <a href="https://docs.marklogic.com/xdmp:javascript-eval">xdmp:javascript-eval()</a> to get around this.</p>
+            <p><em>TODO</em></p>
 
-<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>xquery version "1.0-ml";
+            <h2 id="testing-xquery-with-xquery">Testing XQuery With XQuery</h2>
 
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+            <p><em>TODO</em></p>
+
+            <h2 id="test-server-side-javascript-with-xquery">
+              Test Server-side JavaScript with XQuery
+            </h2>
+
+            <p><em>TODO: is this information current?</em></p>
+
+            <p>
+              You can write unit tests in XQuery to test code written in
+              JavaScript. The one tricky part is that you can’t import an .sjs
+              module (such as the code you want to test) in XQuery. You can use
+              <a href="https://docs.marklogic.com/xdmp:javascript-eval"
+                >xdmp:javascript-eval()</a
+              >
+              to get around this.
+            </p>
+
+            <div class="highlighter-rouge">
+              <div class="highlight">
+                <pre class="highlight"><code>xquery version "1.0-ml";
+
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 
 let $actual := xdmp:javascript-eval(
   "var simple = require ('/lib/simple.sjs');
@@ -215,45 +268,65 @@ let $actual := xdmp:javascript-eval(
 return (
   test:assert-equal(2, $actual)
 )
-</code></pre></div></div>
+</code></pre>
+              </div>
+            </div>
 
-<p>This is very similar overall to testing XQuery with XQuery, except that generating the $actual response happens in an eval.</p>
-
-
+            <p>
+              This is very similar overall to testing XQuery with XQuery, except
+              that generating the $actual response happens in an eval.
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-  </article>
-
+    </article>
 
     <footer class="site-footer">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
-                    Copyright © 2016-2018 MarkLogic Corporation. All Rights Reserved. MARKLOGIC® is a registered trademark of MarkLogic Corporation.
-                    </p>
-                </div>
-            </div>
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <p>
+              Copyright © 2016-2018 MarkLogic Corporation. All Rights Reserved.
+              MARKLOGIC® is a registered trademark of MarkLogic Corporation.
+            </p>
+          </div>
         </div>
+      </div>
     </footer>
 
-
     <!--[if lt IE 9]>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="/marklogic-unit-test/js/respond.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="/marklogic-unit-test/js/respond.min.js"></script>
     <![endif]-->
 
-    <script type="text/javascript" src="/marklogic-unit-test/assets/bundle.js" id="1"></script>
+    <script
+      type="text/javascript"
+      src="/marklogic-unit-test/assets/bundle.js"
+      id="1"
+    ></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
+      );
 
-      ga('create', 'UA-79716597-1', 'auto');
-      ga('send', 'pageview');
+      ga("create", "UA-79716597-1", "auto");
+      ga("send", "pageview");
     </script>
   </body>
 </html>
-

--- a/docs/transactional/index.html
+++ b/docs/transactional/index.html
@@ -1,246 +1,345 @@
-<!doctype html>
-<!--[if lt IE 7 ]><html itemscope itemtype="http://schema.org/Organization" id="ie6" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 7 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie7" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 8 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie8" class="ie ie-old" lang="en-US"><![endif]-->
-<!--[if IE 9 ]>   <html itemscope itemtype="http://schema.org/Organization" id="ie9" class="ie" lang="en-US"><![endif]-->
-<!--[if gt IE 9]><!--><html itemscope itemtype="http://schema.org/Organization" lang="en-US"><!--<![endif]-->
-<head>
-
+<!DOCTYPE html>
+<!--[if lt IE 7]><html itemscope itemtype="http://schema.org/Organization" id="ie6" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 7]>   <html itemscope itemtype="http://schema.org/Organization" id="ie7" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 8]>   <html itemscope itemtype="http://schema.org/Organization" id="ie8" class="ie ie-old" lang="en-US"><![endif]-->
+<!--[if IE 9]>   <html itemscope itemtype="http://schema.org/Organization" id="ie9" class="ie" lang="en-US"><![endif]-->
+<!--[if gt IE 9]><!--><html
+  itemscope
+  itemtype="http://schema.org/Organization"
+  lang="en-US"
+><!--<![endif]-->
+  <head>
     <!-- Meta -->
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Transactional Unit Tests - MarkLogic Unit Test</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <meta content="yes" name="apple-mobile-web-app-capable">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
+    <meta content="yes" name="apple-mobile-web-app-capable" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
 
     <!-- Favicons -->
-    <link rel="shortcut icon" sizes="16x16 24x24 32x32 48x48 64x64 96x96" href="/marklogic-unit-test/favicon.ico">
-    <meta name="application-name" content="MarkLogic Unit Test - A Unit Test framework for MarkLogic">
+    <link
+      rel="shortcut icon"
+      sizes="16x16 24x24 32x32 48x48 64x64 96x96"
+      href="/marklogic-unit-test/favicon.ico"
+    />
+    <meta
+      name="application-name"
+      content="MarkLogic Unit Test - A Unit Test framework for MarkLogic"
+    />
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
+      );
 
-      ga('create', 'UA-6638631-15', 'auto');
-      ga('send', 'pageview');
-
+      ga("create", "UA-6638631-15", "auto");
+      ga("send", "pageview");
     </script>
 
     <!-- Facebook Pixel Code -->
     <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '1879746318909687'); // Insert your pixel ID here.
-    fbq('track', 'PageView');
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod
+            ? n.callMethod.apply(n, arguments)
+            : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = "2.0";
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        "script",
+        "https://connect.facebook.net/en_US/fbevents.js"
+      );
+      fbq("init", "1879746318909687"); // Insert your pixel ID here.
+      fbq("track", "PageView");
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=1879746318909687&ev=PageView&noscript=1"
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=1879746318909687&ev=PageView&noscript=1"
     /></noscript>
     <!-- DO NOT MODIFY -->
     <!-- End Facebook Pixel Code -->
-    <link type="text/css" rel="stylesheet" href="/marklogic-unit-test/assets/bundle.css">
-</head>
-<body class="">
-
+    <link
+      type="text/css"
+      rel="stylesheet"
+      href="/marklogic-unit-test/assets/bundle.css"
+    />
+  </head>
+  <body class="">
     <nav class="navbar navbar-inverse">
-        <div class="container-fluid">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-                <a class="navbar-brand" href="/marklogic-unit-test">
-                  <span class="logo">
-                    <img src="/marklogic-unit-test/images/logo-marklogic.svg" width="180px" height="38px" alt="MarkLogic" title="MarkLogic" scale="0">
-                  </span>
-                  MarkLogic Unit Test
-                </a>
-            </div>
-            <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-right">
-                    
-                        <li  >
-                            
-                            <a href="/marklogic-unit-test/">Getting Started</a>
-                            
-                        </li>
-                    
-                        <li  >
-                            
-                            <a href="https://github.com/marklogic-community/marklogic-unit-test">GitHub</a>
-                            
-                        </li>
-                    
-                </ul>
-            </div>
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle collapsed"
+            data-toggle="collapse"
+            data-target="#navbar"
+            aria-expanded="false"
+            aria-controls="navbar"
+          >
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/marklogic-unit-test">
+            <span class="logo">
+              <img
+                src="/marklogic-unit-test/images/logo-marklogic.svg"
+                width="180px"
+                height="38px"
+                alt="MarkLogic"
+                title="MarkLogic"
+                scale="0"
+              />
+            </span>
+            MarkLogic Unit Test
+          </a>
         </div>
+        <div id="navbar" class="navbar-collapse collapse">
+          <ul class="nav navbar-nav navbar-right">
+            <li>
+              <a href="/marklogic-unit-test/">Getting Started</a>
+            </li>
+
+            <li>
+              <a
+                href="https://github.com/marklogic-community/marklogic-unit-test"
+                >GitHub</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
     </nav>
 
+    <article>
+      <div class="container">
+        <div class="row">
+          <div class="side-nav col-md-3 hide-small">
+            <div class="panel panel-default">
+              <div class="panel-heading">Navigation</div>
+              <ul class="list-group">
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/">Getting Started</a>
+                </li>
 
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/include/"
+                    >How to Include MarkLogic Unit Test in Your Project</a
+                  >
+                </li>
 
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/running/"
+                    >How to Run Your Tests</a
+                  >
+                </li>
 
-  <article>
-    <div class="container">
-      <div class="row">
-        <div class="side-nav col-md-3 hide-small">
-          <div class="panel panel-default">
-  <div class="panel-heading">Navigation</div>
-  <ul class="list-group">
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/">Getting Started</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/include/">How to Include MarkLogic Unit Test in Your Project</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/running/">How to Run Your Tests</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/">Docs</a>
-    
-    
-      <ul class="list-group">
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/conventions/">Filename Conventions</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/loading-data/">Loading Data</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/testing-with-sjs/">Testing With JavaScript</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/testing-with-xquery/">Testing With XQuery</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/docs/assertions/">Assert Functions</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item active"  >
-    
-    <a href="/marklogic-unit-test/docs/transactional/">Transactional Unit Tests</a>
-    
-    
-  </li>
-  
-</ul>
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/docs/">Docs</a>
 
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="/marklogic-unit-test/good-tests/">Guidelines for Writing Good Tests</a>
-    
-    
-  </li>
-  
-  <li  class="list-group-item"  >
-    
-    <a href="https://github.com/marklogic-community/marklogic-unit-test">MarkLogic Unit Test on GitHub</a>
-    
-    
-  </li>
-  
-</ul>
+                  <ul class="list-group">
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/conventions/"
+                        >Filename Conventions</a
+                      >
+                    </li>
 
-</div>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/loading-data/"
+                        >Loading Data</a
+                      >
+                    </li>
 
-        </div>
-        <div class="col-md-9">
-          <h1 id="transactional-unit-tests">Transactional Unit Tests</h1>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/testing-with-sjs/"
+                        >Testing With JavaScript</a
+                      >
+                    </li>
 
-<p><em>TODO: best practice check; differences for SJS?</em></p>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/testing-with-xquery/"
+                        >Testing With XQuery</a
+                      >
+                    </li>
 
-<p>Sometimes your unit tests will need to commit a transaction and check the results. Here’s how to go about it.</p>
+                    <li class="list-group-item">
+                      <a href="/marklogic-unit-test/docs/assertions/"
+                        >Assert Functions</a
+                      >
+                    </li>
 
-<p>Scenario: suppose you have <code class="highlighter-rouge">tag-lib.xqy</code>, which manages tags in your documents. In <code class="highlighter-rouge">tag-lib.xqy</code>, you have 
-<code class="highlighter-rouge">tag:add($docid, $tag)</code>, which will add the tag to the matching document if the tag isn’t already there, and do nothing 
-if it already is.</p>
+                    <li class="list-group-item active">
+                      <a href="/marklogic-unit-test/docs/transactional/"
+                        >Transactional Unit Tests</a
+                      >
+                    </li>
+                  </ul>
+                </li>
 
-<h2 id="the-problem">The problem</h2>
-<p>In your unit test, you call the <code class="highlighter-rouge">tag:add()</code> function and update the target document. The problem is that the change 
-won’t be visible until the transaction completes, as discussed <a href="http://docs.marklogic.com/guide/app-dev/transactions#id_85012">in the Application Developer’s Guide</a>. 
-To be an effective test, we need to check that the results were written correctly.</p>
+                <li class="list-group-item">
+                  <a href="/marklogic-unit-test/good-tests/"
+                    >Guidelines for Writing Good Tests</a
+                  >
+                </li>
 
-<h2 id="solutions">Solutions</h2>
+                <li class="list-group-item">
+                  <a
+                    href="https://github.com/marklogic-community/marklogic-unit-test"
+                    >MarkLogic Unit Test on GitHub</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-9">
+            <h1 id="transactional-unit-tests">Transactional Unit Tests</h1>
 
-<p>We’ll assume we have a suite called tag-lib (<code class="highlighter-rouge">src/test/suites/tag-lib/</code>) and that we’ll test the <code class="highlighter-rouge">tag:add</code> function in 
-<code class="highlighter-rouge">add.xqy</code>.</p>
+            <p><em>TODO: best practice check; differences for SJS?</em></p>
 
-<h3 id="first-approach-setupxqy">First Approach: setup.xqy</h3>
-<p>The first approach is to create a document in <code class="highlighter-rouge">setup.xqy</code> (a simple <code class="highlighter-rouge">xdmp:document-insert</code> with a fixed URL and a basic 
-sample document). You’ll use <code class="highlighter-rouge">setup.xqy</code> instead of <code class="highlighter-rouge">suite-setup.xqy</code>, because <code class="highlighter-rouge">setup.xqy</code> will be run before each test, 
-overwriting the result of your change.</p>
+            <p>
+              Sometimes your unit tests will need to commit a transaction and
+              check the results. Here’s how to go about it.
+            </p>
 
-<p>In your test module, <code class="highlighter-rouge">add.xqy</code>, you’ll import <code class="highlighter-rouge">tag-lib.xqy</code> and call the <code class="highlighter-rouge">tag:add</code> function. If all goes well, the 
-document will get updated with the new tag. In order to see it, we need to end the transaction and start a new one. We 
-can use the semicolon operator for this.</p>
+            <p>
+              Scenario: suppose you have
+              <code class="highlighter-rouge">tag-lib.xqy</code>, which manages
+              tags in your documents. In
+              <code class="highlighter-rouge">tag-lib.xqy</code>, you have
+              <code class="highlighter-rouge">tag:add($docid, $tag)</code>,
+              which will add the tag to the matching document if the tag isn’t
+              already there, and do nothing if it already is.
+            </p>
 
-<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>(: tag.xqy :)
-import module namespace tag = "http://marklogic.com/roxy/tag-lib" at "/app/modules/tag-lib.xqy";
+            <h2 id="the-problem">The problem</h2>
+            <p>
+              In your unit test, you call the
+              <code class="highlighter-rouge">tag:add()</code> function and
+              update the target document. The problem is that the change won’t
+              be visible until the transaction completes, as discussed
+              <a
+                href="http://docs.marklogic.com/guide/app-dev/transactions#id_85012"
+                >in the Application Developer’s Guide</a
+              >. To be an effective test, we need to check that the results were
+              written correctly.
+            </p>
+
+            <h2 id="solutions">Solutions</h2>
+
+            <p>
+              We’ll assume we have a suite called tag-lib (<code
+                class="highlighter-rouge"
+                >src/test/suites/tag-lib/</code
+              >) and that we’ll test the
+              <code class="highlighter-rouge">tag:add</code> function in
+              <code class="highlighter-rouge">add.xqy</code>.
+            </p>
+
+            <h3 id="first-approach-setupxqy">First Approach: setup.xqy</h3>
+            <p>
+              The first approach is to create a document in
+              <code class="highlighter-rouge">setup.xqy</code> (a simple
+              <code class="highlighter-rouge">xdmp:document-insert</code> with a
+              fixed URL and a basic sample document). You’ll use
+              <code class="highlighter-rouge">setup.xqy</code> instead of
+              <code class="highlighter-rouge">suite-setup.xqy</code>, because
+              <code class="highlighter-rouge">setup.xqy</code> will be run
+              before each test, overwriting the result of your change.
+            </p>
+
+            <p>
+              In your test module,
+              <code class="highlighter-rouge">add.xqy</code>, you’ll import
+              <code class="highlighter-rouge">tag-lib.xqy</code> and call the
+              <code class="highlighter-rouge">tag:add</code> function. If all
+              goes well, the document will get updated with the new tag. In
+              order to see it, we need to end the transaction and start a new
+              one. We can use the semicolon operator for this.
+            </p>
+
+            <div class="highlighter-rouge">
+              <div class="highlight">
+                <pre class="highlight"><code>(: tag.xqy :)
+import module namespace tag = "http://marklogic.com/tag-lib" at "/app/modules/tag-lib.xqy";
 tag:add("/test1.xml", "tag1")
 
 ;
 
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 test:assert-exists(fn:doc("/test1.xml")/doc/meta/tags/tag[./text() = "tag1"]`
-</code></pre></div></div>
+</code></pre>
+              </div>
+            </div>
 
-<p>(Note that to isolate knowledge of how tags are stored, you might want to use a tag module function to retrieve it. The tradeoff is that if the retrieving function breaks, it will look like <code class="highlighter-rouge">add()</code> doesn’t work either.)</p>
+            <p>
+              (Note that to isolate knowledge of how tags are stored, you might
+              want to use a tag module function to retrieve it. The tradeoff is
+              that if the retrieving function breaks, it will look like
+              <code class="highlighter-rouge">add()</code> doesn’t work either.)
+            </p>
 
-<p>Anyway, the semicolon ends one transaction, allowing the change to be fully committed. Then in the second transaction 
-(after the semicolon), we can check whether or not it worked.</p>
+            <p>
+              Anyway, the semicolon ends one transaction, allowing the change to
+              be fully committed. Then in the second transaction (after the
+              semicolon), we can check whether or not it worked.
+            </p>
 
-<h3 id="second-approach-test-specific-setup-and-teardown">Second approach: test-specific setup and teardown</h3>
-<p>The first approach sets up data for all tests. You might have a test that needs data that are different from the of 
-the test suite, and thus you don’t want to put it into setup.xqy (or suite-setup.xqy). This second pattern shows you 
-how to do this.</p>
+            <h3 id="second-approach-test-specific-setup-and-teardown">
+              Second approach: test-specific setup and teardown
+            </h3>
+            <p>
+              The first approach sets up data for all tests. You might have a
+              test that needs data that are different from the of the test
+              suite, and thus you don’t want to put it into setup.xqy (or
+              suite-setup.xqy). This second pattern shows you how to do this.
+            </p>
 
-<p>In a nutshell, you’ll use four transactions (three semicolons) within your test module: setup, test, verify, and teardown.</p>
+            <p>
+              In a nutshell, you’ll use four transactions (three semicolons)
+              within your test module: setup, test, verify, and teardown.
+            </p>
 
-<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>(: add.xqy
+            <div class="highlighter-rouge">
+              <div class="highlight">
+                <pre class="highlight"><code>(: add.xqy
   : setup
   :)
 xdmp:document-insert("/test1.xml", 
@@ -253,7 +352,7 @@ xdmp:document-insert("/test1.xml",
 ;
 
 (: test :)
-import module namespace tag = "http://marklogic.com/roxy/tag-lib" at "/app/modules/tag-lib.xqy";
+import module namespace tag = "http://marklogic.com/tag-lib" at "/app/modules/tag-lib.xqy";
 
 try {
   tag:add("/test1.xml", "tag1")
@@ -264,7 +363,7 @@ try {
 ;
 
 (: verify :)
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 
 try {
   test:assert-exists(fn:doc("/test1.xml")/doc/meta/tags/tag[./text() = "tag1"])
@@ -279,50 +378,79 @@ try {
 
 (: teardown :)
 xdmp:document-delete("/test1.xml")
-</code></pre></div></div>
+</code></pre>
+              </div>
+            </div>
 
-<p>Note the try/catches in the test and verify stages. The reason for these is that if an exception were thrown and not 
-caught, the teardown section would not get run, polluting your test database with something that’s not supposed to be 
-there. If one of the assertions fails, that will trigger an exception. If the exception is a failed assertion, we need 
-to rethrow to make sure the results get counted. Otherwise, everything can look okay even when there is a failing test.</p>
+            <p>
+              Note the try/catches in the test and verify stages. The reason for
+              these is that if an exception were thrown and not caught, the
+              teardown section would not get run, polluting your test database
+              with something that’s not supposed to be there. If one of the
+              assertions fails, that will trigger an exception. If the exception
+              is a failed assertion, we need to rethrow to make sure the results
+              get counted. Otherwise, everything can look okay even when there
+              is a failing test.
+            </p>
 
-<p><em>Note from Dave Cassel: this second approach can be a bit error prone, with mistakes leading to quietly failing tests. Based on that, I’d use the first approach whenever possible.</em></p>
-
-
+            <p>
+              <em
+                >Note from Dave Cassel: this second approach can be a bit error
+                prone, with mistakes leading to quietly failing tests. Based on
+                that, I’d use the first approach whenever possible.</em
+              >
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-  </article>
-
+    </article>
 
     <footer class="site-footer">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
-                    Copyright © 2016-2018 MarkLogic Corporation. All Rights Reserved. MARKLOGIC® is a registered trademark of MarkLogic Corporation.
-                    </p>
-                </div>
-            </div>
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <p>
+              Copyright © 2016-2018 MarkLogic Corporation. All Rights Reserved.
+              MARKLOGIC® is a registered trademark of MarkLogic Corporation.
+            </p>
+          </div>
         </div>
+      </div>
     </footer>
 
-
     <!--[if lt IE 9]>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="/marklogic-unit-test/js/respond.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="/marklogic-unit-test/js/respond.min.js"></script>
     <![endif]-->
 
-    <script type="text/javascript" src="/marklogic-unit-test/assets/bundle.js" id="1"></script>
+    <script
+      type="text/javascript"
+      src="/marklogic-unit-test/assets/bundle.js"
+      id="1"
+    ></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
+      );
 
-      ga('create', 'UA-79716597-1', 'auto');
-      ga('send', 'pageview');
+      ga("create", "UA-79716597-1", "auto");
+      ga("send", "pageview");
     </script>
   </body>
 </html>
-

--- a/running/index.html
+++ b/running/index.html
@@ -234,7 +234,7 @@ configuration you set up (see <a href="../include/">How to Include MarkLogic Uni
 
 <p>The response will look like this:</p>
 
-<div class="language-xml highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nt">&lt;t:tests</span> <span class="na">xmlns:t=</span><span class="s">"http://marklogic.com/roxy/test"</span><span class="nt">&gt;</span>
+<div class="language-xml highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nt">&lt;t:tests</span> <span class="na">xmlns:t=</span><span class="s">"http://marklogic.com/test"</span><span class="nt">&gt;</span>
   <span class="nt">&lt;t:suite</span> <span class="na">path=</span><span class="s">"auditing"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;t:tests&gt;</span>
       <span class="nt">&lt;t:test</span> <span class="na">path=</span><span class="s">"document-history.sjs"</span><span class="nt">/&gt;</span>


### PR DESCRIPTION
Updating to remove some Roxy references. In particular, some sections showed XQuery imports using namespaces with Roxy in them. Those are no longer correct, leading to inaccurate examples. 