### PR TITLE
Removing Roxy references

### DIFF
--- a/docs/loading-data/index.html
+++ b/docs/loading-data/index.html
@@ -191,8 +191,6 @@
         <div class="col-md-9">
           <h2 id="loading-data">Loading Data</h2>
 
-<p><em>TODO: replace Roxy content with marklogic-unit-test</em></p>
-
 <p>MarkLogic Unit Test simplifies loading data for your tests. Files to be loaded can be placed in a sub-directory of your test suite called <code class="highlighter-rouge">test-data</code>. The test helper provides a function which will automatically use this directory as the location of test files to be loaded.</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>test:load-data-file(&lt;name-of-file-to-be-loaded-without-path&gt;,database id, &lt;URI&gt;)
@@ -209,7 +207,7 @@ setup script could look like this in JavaScript:</p>
 
 <p>… and in XQuery:</p>
 
-<div class="language-xquery highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">test</span> <span class="o">=</span> <span class="s2">"http://marklogic.com/roxy/test-helper"</span> <span class="k">at</span> <span class="s2">"/test/test-helper.xqy"</span><span class="p">;</span>
+<div class="language-xquery highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">test</span> <span class="o">=</span> <span class="s2">"http://marklogic.com/test"</span> <span class="k">at</span> <span class="s2">"/test/test-helper.xqy"</span><span class="p">;</span>
 <span class="kp">import</span> <span class="kp">module</span> <span class="k">namespace</span> <span class="nn">lib</span> <span class="o">=</span> <span class="s2">"http://example.com/test/lib"</span> <span class="k">at</span> <span class="s2">"lib/lib.xqy"</span><span class="p">;</span>
 
 <span class="nf">test:load-test-file</span><span class="p">(</span><span class="s2">"test-article.xml"</span><span class="p">,</span> <span class="nf">xdmp:database</span><span class="p">(),</span> <span class="nv">$</span><span class="n">lib:URI</span><span class="p">)</span>

--- a/docs/testing-with-xquery/index.html
+++ b/docs/testing-with-xquery/index.html
@@ -205,7 +205,7 @@
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>xquery version "1.0-ml";
 
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 
 let $actual := xdmp:javascript-eval(
   "var simple = require ('/lib/simple.sjs');

--- a/docs/transactional/index.html
+++ b/docs/transactional/index.html
@@ -219,12 +219,12 @@ document will get updated with the new tag. In order to see it, we need to end t
 can use the semicolon operator for this.</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>(: tag.xqy :)
-import module namespace tag = "http://marklogic.com/roxy/tag-lib" at "/app/modules/tag-lib.xqy";
+import module namespace tag = "http://marklogic.com/tag-lib" at "/app/modules/tag-lib.xqy";
 tag:add("/test1.xml", "tag1")
 
 ;
 
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 test:assert-exists(fn:doc("/test1.xml")/doc/meta/tags/tag[./text() = "tag1"]`
 </code></pre></div></div>
 
@@ -253,7 +253,7 @@ xdmp:document-insert("/test1.xml",
 ;
 
 (: test :)
-import module namespace tag = "http://marklogic.com/roxy/tag-lib" at "/app/modules/tag-lib.xqy";
+import module namespace tag = "http://marklogic.com/tag-lib" at "/app/modules/tag-lib.xqy";
 
 try {
   tag:add("/test1.xml", "tag1")
@@ -264,7 +264,7 @@ try {
 ;
 
 (: verify :)
-import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
 
 try {
   test:assert-exists(fn:doc("/test1.xml")/doc/meta/tags/tag[./text() = "tag1"])

--- a/running/index.html
+++ b/running/index.html
@@ -234,7 +234,7 @@ configuration you set up (see <a href="../include/">How to Include MarkLogic Uni
 
 <p>The response will look like this:</p>
 
-<div class="language-xml highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nt">&lt;t:tests</span> <span class="na">xmlns:t=</span><span class="s">"http://marklogic.com/roxy/test"</span><span class="nt">&gt;</span>
+<div class="language-xml highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nt">&lt;t:tests</span> <span class="na">xmlns:t=</span><span class="s">"http://marklogic.com/test"</span><span class="nt">&gt;</span>
   <span class="nt">&lt;t:suite</span> <span class="na">path=</span><span class="s">"auditing"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;t:tests&gt;</span>
       <span class="nt">&lt;t:test</span> <span class="na">path=</span><span class="s">"document-history.sjs"</span><span class="nt">/&gt;</span>


### PR DESCRIPTION
There were some Roxy references in sample code. Where they occur in XQuery `import` statements, this causes the imports to fail due to namespace mismatches. Removed a few other non-breaking but outdated references as well. 