### PR TITLE
modified the failure report and added codecoverage report when enabled

### DIFF
--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/DefaultJUnitTestReporter.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/DefaultJUnitTestReporter.java
@@ -1,6 +1,8 @@
 package com.marklogic.test.unit;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Default implementation that is fairly similar to how the Gradle "test" task reports errors.
@@ -13,7 +15,7 @@ public class DefaultJUnitTestReporter implements JUnitTestReporter {
 
 		int testsCompleted = 0;
 		int testFailed = 0;
-
+    sb.append("\n\nTest Results:");
 		for (JUnitTestSuite suite : suites) {
 			if (suite.getTestCases() == null) {
 				continue;
@@ -22,14 +24,71 @@ public class DefaultJUnitTestReporter implements JUnitTestReporter {
 				testsCompleted++;
 				if (testCase.hasTestFailures()) {
 					testFailed++;
-					sb.append("\n\n" + testCase.getClassname() + " > " + testCase.getName() + " FAILED");
+					sb.append("\n\n").append(testCase.getClassname()).
+            append(" > ").append(testCase.getName()).
+            append(" FAILED");
 					for (JUnitTestFailure failure : testCase.getTestFailures()) {
-						sb.append("\n    " + failure.getMessage());
+						sb.append("\n    ").append(failure.getMessage());
 					}
 				}
 			}
 		}
-		sb.append("\n\n" + testsCompleted + " tests completed, " + testFailed + " failed");
+		sb.append("\n\n").append(testsCompleted).
+      append(" tests completed, ").append(testFailed).
+      append(" failed");
 		return sb.toString();
 	}
+
+  public String reportOnJUnitTestSuitesCoverage(List<JUnitTestSuite> suites) {
+    StringBuilder sb = new StringBuilder();
+
+    int testsCovered = 0;
+    Map<String, Map<String, Integer>> modulesAnalyzed = new HashMap<>();
+    sb.append("\n\nCoverage Results:");
+    sb.append("\n\nCoverage Per Test");
+    for (JUnitTestSuite suite : suites) {
+      if (suite.getTestCases() == null) {
+        continue;
+      }
+      for (JUnitTestCase testCase : suite.getTestCases()) {
+        testsCovered++;
+        if (testCase.hasTestCoverages()) {
+          sb.append("\n\n").append(testCase.getClassname()).
+            append(" > ").append(testCase.getName()).
+            append(" COVERED");
+          for (JUnitTestCoverage coverage : testCase.getTestCoverages()) {
+            String module = coverage.getModule();
+            List<JUnitTestCoverageInfo> coverInfo = coverage.getCoverageInfo();
+            if (modulesAnalyzed.containsKey(module)) {
+              Map<String,Integer> analyzed = modulesAnalyzed.get(module);
+              Integer wantedCount = coverInfo.get(0).getCount();
+              Integer coveredCount = coverInfo.get(1).getCount();
+              if (analyzed.get("wanted") < wantedCount) {
+                analyzed.put("wanted", wantedCount);
+              }
+              if (analyzed.get("covered") < coveredCount) {
+                analyzed.put("covered", coveredCount);
+              }
+              analyzed.put("missing", analyzed.get("wanted") - analyzed.get("covered"));
+            } else {
+              Map<String,Integer> analyzed = new HashMap<>();
+              for (JUnitTestCoverageInfo jUnitTestCoverageInfo : coverInfo) {
+                analyzed.put(jUnitTestCoverageInfo.getType(), jUnitTestCoverageInfo.getCount());
+              }
+              modulesAnalyzed.put(module, analyzed);
+            }
+            sb.append("\n    ").append(coverage);
+          }
+        }
+      }
+    }
+    sb.append("\n\n").append(testsCovered).
+      append(" tests covered").append("\n\nCoverage Across All Tests:\n");
+    modulesAnalyzed.forEach(
+      (key,value) -> sb.append("\t[module: ").
+        append(key).append(", coverageInfo: ").
+        append(value).append("]\n")
+    );
+    return sb.toString();
+  }
 }

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCase.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCase.java
@@ -9,15 +9,26 @@ import java.util.List;
  */
 public class JUnitTestCase {
 
-	private String classname;
-	private String name;
-	private double time;
-	private List<JUnitTestFailure> testFailures;
+	private final String classname;
+	private final String name;
+	private final double time;
 
-	public JUnitTestCase(String name, String classname, double time) {
+  private final int tests;
+
+  private final int success;
+
+  private final int fail;
+
+	private List<JUnitTestFailure> testFailures;
+  private List<JUnitTestCoverage> testCoverages;
+
+	public JUnitTestCase(String name, String classname, double time, int tests, int success, int fail) {
 		this.name = name;
 		this.classname = classname;
 		this.time = time;
+    this.tests = tests;
+    this.success = success;
+    this.fail = fail;
 	}
 
 	public void addTestFailure(JUnitTestFailure testFailure) {
@@ -31,10 +42,21 @@ public class JUnitTestCase {
 		return testFailures != null && !testFailures.isEmpty();
 	}
 
+  public void addTestCoverage(JUnitTestCoverage testCoverage) {
+    if (testCoverages == null) {
+      testCoverages = new ArrayList<>();
+    }
+    testCoverages.add(testCoverage);
+  }
+
+  public boolean hasTestCoverages() {
+    return testCoverages != null && !testCoverages.isEmpty();
+  }
+
 	@Override
 	public String toString() {
-		return String.format("[name: %s, classname: %s, time: %f, testFailures: %s]",
-			name, classname, time, testFailures);
+		return String.format("[name: %s, classname: %s, time: %f, testFailures: %s, testCoverages: %s]",
+			name, classname, time, testFailures, testCoverages);
 	}
 
 	public String getClassname() {
@@ -49,11 +71,27 @@ public class JUnitTestCase {
 		return time;
 	}
 
-	public List<JUnitTestFailure> getTestFailures() {
+  public int getTests() {
+    return tests;
+  }
+
+  public int getSuccess() {
+    return success;
+  }
+
+  public int getFail() {
+    return fail;
+  }
+
+  public List<JUnitTestFailure> getTestFailures() {
 		return testFailures;
 	}
 
 	public void setTestFailures(List<JUnitTestFailure> testFailures) {
 		this.testFailures = testFailures;
 	}
+
+  public List<JUnitTestCoverage> getTestCoverages() {
+    return testCoverages;
+  }
 }

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCoverage.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCoverage.java
@@ -1,0 +1,34 @@
+package com.marklogic.test.unit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JUnitTestCoverage {
+  private final String module;
+
+  private List<JUnitTestCoverageInfo> coverageInfo;
+
+  public JUnitTestCoverage(String module) {
+    this.module = module;
+  }
+
+  public String getModule() {
+    return module;
+  }
+
+  public void addCoverageInfo(JUnitTestCoverageInfo coverageInfo) {
+    if (this.coverageInfo == null) {
+      this.coverageInfo = new ArrayList<>();
+    }
+    this.coverageInfo.add(coverageInfo);
+  }
+
+  public List<JUnitTestCoverageInfo> getCoverageInfo() {
+    return coverageInfo;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[module: %s, coverageInfo: %s]", module, coverageInfo);
+  }
+}

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCoverageInfo.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestCoverageInfo.java
@@ -1,0 +1,30 @@
+package com.marklogic.test.unit;
+
+public class JUnitTestCoverageInfo {
+  private final String type;
+  private final int count;
+  private final String infoXml;
+
+  public JUnitTestCoverageInfo(String type, int count, String infoXml) {
+    this.type = type;
+    this.count = count;
+    this.infoXml = infoXml;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public String getInfoXml() {
+    return infoXml;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%s: %d]", type, count);
+  }
+}

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestFailure.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestFailure.java
@@ -5,9 +5,9 @@ package com.marklogic.test.unit;
  */
 public class JUnitTestFailure {
 
-	private String type;
-	private String message;
-	private String failureXml;
+	private final String type;
+	private final String message;
+	private final String failureXml;
 
 	public JUnitTestFailure(String type, String message, String failureXml) {
 		this.type = type;

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestReporter.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestReporter.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface JUnitTestReporter {
 
 	String reportOnJUnitTestSuites(List<JUnitTestSuite> suites);
+
+  String reportOnJUnitTestSuitesCoverage(List<JUnitTestSuite> suites);
 }

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestSuite.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JUnitTestSuite.java
@@ -9,16 +9,18 @@ import java.util.List;
  */
 public class JUnitTestSuite {
 
-	private String xml;
-	private int errors;
-	private int failures;
-	private String hostname;
-	private String name;
-	private int tests;
-	private double time;
+	private final String xml;
+	private final int errors;
+	private final int failures;
+	private final String hostname;
+	private final String name;
+	private final int tests;
+	private final double time;
+  private final int cases;
+
 	private List<JUnitTestCase> testCases;
 
-	public JUnitTestSuite(String xml, int errors, int failures, String hostname, String name, int tests, double time) {
+	public JUnitTestSuite(String xml, int errors, int failures, String hostname, String name, int cases, int tests, double time) {
 		this.xml = xml;
 		this.errors = errors;
 		this.failures = failures;
@@ -26,6 +28,7 @@ public class JUnitTestSuite {
 		this.name = name;
 		this.tests = tests;
 		this.time = time;
+    this.cases = cases;
 	}
 
 	public void addTestCase(JUnitTestCase testCase) {
@@ -49,8 +52,8 @@ public class JUnitTestSuite {
 
 	@Override
 	public String toString() {
-		return String.format("[name: %s, tests: %d, errors: %d, failures: %d, hostname: %s, time: %f, testCases: %s]",
-			name, tests, errors, failures, hostname, time, testCases);
+		return String.format("[name: %s, tests: %d, cases: %d, errors: %d, failures: %d, hostname: %s, time: %f, testCases: %s]",
+			name, tests, cases, errors, failures, hostname, time, testCases);
 	}
 
 	public int getErrors() {
@@ -84,4 +87,8 @@ public class JUnitTestSuite {
 	public String getXml() {
 		return xml;
 	}
+
+  public int getCases() {
+    return cases;
+  }
 }

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JaxpServiceResponseUnmarshaller.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/JaxpServiceResponseUnmarshaller.java
@@ -1,9 +1,12 @@
 package com.marklogic.test.unit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -14,11 +17,9 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
-import org.xml.sax.InputSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JAXP-based implementation. Not the prettiest code, but doesn't have any 3rd-party dependencies,
@@ -26,134 +27,178 @@ import org.slf4j.LoggerFactory;
  */
 public class JaxpServiceResponseUnmarshaller implements ServiceResponseUnmarshaller {
 
-	protected final Logger logger = LoggerFactory.getLogger(getClass());
-	private DocumentBuilder documentBuilder;
-	private static int ELEMENT_TYPE = 1;	
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+  private DocumentBuilder documentBuilder;
+  private static final int ELEMENT_TYPE = 1;
 
-	@Override
-	public List<TestModule> parseTestList(String xml) {
-		NodeList kids = parse(xml).getDocumentElement().getChildNodes();
-		List<TestModule> testModules = new ArrayList<>();
-		for (int i = 0; i < kids.getLength(); i++) {
-			Node suiteNode = kids.item(i);
-			if ("suite".equals(suiteNode.getLocalName())
-				&& "http://marklogic.com/test".equals(suiteNode.getNamespaceURI())) {
-				String suite = suiteNode.getAttributes().getNamedItem("path").getTextContent();
-				NodeList testsNodes = suiteNode.getChildNodes();
-				for (int j = 0; j < testsNodes.getLength(); j++) {
-					NodeList testNodes = testsNodes.item(j).getChildNodes();
-					for (int k = 0; k < testNodes.getLength(); k++) {
-						Node testNode = testNodes.item(k);
-						String test = testNode.getAttributes().getNamedItem("path").getTextContent();
-						testModules.add(new TestModule(test, suite));
-					}
-				}
-			}
-		}
-		return testModules;
-	}
+  @Override
+  public List<TestModule> parseTestList(String xml) {
+    NodeList kids = parse(xml).getDocumentElement().getChildNodes();
+    List<TestModule> testModules = new ArrayList<>();
+    for (int i = 0; i < kids.getLength(); i++) {
+      Node suiteNode = kids.item(i);
+      if ("suite".equals(suiteNode.getLocalName())
+        && "http://marklogic.com/test".equals(suiteNode.getNamespaceURI())) {
+        String suite = suiteNode.getAttributes().getNamedItem("path").getTextContent();
+        NodeList testsNodes = suiteNode.getChildNodes();
+        for (int j = 0; j < testsNodes.getLength(); j++) {
+          NodeList testNodes = testsNodes.item(j).getChildNodes();
+          for (int k = 0; k < testNodes.getLength(); k++) {
+            Node testNode = testNodes.item(k);
+            String test = testNode.getAttributes().getNamedItem("path").getTextContent();
+            testModules.add(new TestModule(test, suite));
+          }
+        }
+      }
+    }
+    return testModules;
+  }
 
-	@Override
-	public TestSuiteResult parseTestSuiteResult(String xml) {
-		Element root = parse(xml).getDocumentElement();
-		String name = root.getAttribute("name");
-		int total = Integer.parseInt(root.getAttribute("total"));
-		int passed = Integer.parseInt(root.getAttribute("passed"));
-		int failed = Integer.parseInt(root.getAttribute("failed"));
-		double time = Double.parseDouble(root.getAttribute("time"));
-		TestSuiteResult testSuiteResult = new TestSuiteResult(xml, name, total, passed, failed, time);
+  @Override
+  public TestSuiteResult parseTestSuiteResult(String xml) {
+    Element root = parse(xml).getDocumentElement();
+    String name = root.getAttribute("name");
+    int total = Integer.parseInt(root.getAttribute("total"));
+    int passed = Integer.parseInt(root.getAttribute("passed"));
+    int failed = Integer.parseInt(root.getAttribute("failed"));
+    double time = Double.parseDouble(root.getAttribute("time"));
+    NodeList testCases = root.getChildNodes();
+    int cases = testCases.getLength();
 
-		NodeList tests = root.getChildNodes();
-		for (int i = 0; i < tests.getLength(); i++) {
-			Element testNode = (Element) tests.item(i);
-			String testName = testNode.getAttribute("name");
-			double testTime = Double.parseDouble(testNode.getAttribute("time"));
-			NodeList resultNodes = testNode.getChildNodes();
-			String failureXml = null;
-			for (int j = 0; j < resultNodes.getLength(); j++) {
-				// An XQuery test module may return additional nodes, such as text nodes, which should be
-				// ignored unless they are element nodes. 				
-				if (resultNodes.item(j).getNodeType() == ELEMENT_TYPE) {
-					Element resultNode = (Element) resultNodes.item(j);
-					if ("fail".equals(resultNode.getAttribute("type"))) {
-						failureXml = toXml(resultNode);
-						break;						
-					}
-				} else {
-					logger.debug("Ignoring Node Type [" + resultNodes.item(j).getNodeType() + "]");
-				}
-			}
-			testSuiteResult.addTestResult(new TestResult(testName, testTime, failureXml));
-		}
+    TestSuiteResult testSuiteResult = new TestSuiteResult(prettyPrintXml(xml), name, cases, total, passed, failed, time);
 
-		return testSuiteResult;
-	}
+    for (int i = 0; i < testCases.getLength(); i++) {
+      Element testNode = (Element) testCases.item(i);
+      String testName = testNode.getAttribute("name");
+      double testTime = Double.parseDouble(testNode.getAttribute("time"));
+      NodeList resultNodes = testNode.getChildNodes();
+      String failureXml = null;
+      for (int j = 0; j < resultNodes.getLength(); j++) {
+        // An XQuery test module may return additional nodes, such as text nodes, which should be
+        // ignored unless they are element nodes.
+        if (resultNodes.item(j).getNodeType() == ELEMENT_TYPE) {
+          Element resultNode = (Element) resultNodes.item(j);
+          if ("fail".equals(resultNode.getAttribute("type"))) {
+            failureXml = toXml(resultNode);
+            break;
+          }
+        } else {
+          logger.debug("Ignoring Node Type [" + resultNodes.item(j).getNodeType() + "]");
+        }
+      }
+      testSuiteResult.addTestResult(new TestResult(testName, testTime, failureXml));
+    }
 
-	@Override
-	public JUnitTestSuite parseJUnitTestSuiteResult(String xml) {
-		Element root = parse(xml).getDocumentElement();
-		int errors = Integer.parseInt(root.getAttribute("errors"));
-		int failures = Integer.parseInt(root.getAttribute("failures"));
-		String hostname = root.getAttribute("hostname");
-		String name = root.getAttribute("name");
-		int tests = Integer.parseInt(root.getAttribute("tests"));
-		double time = Double.parseDouble(root.getAttribute("time"));
-		JUnitTestSuite suite = new JUnitTestSuite(xml, errors, failures, hostname, name, tests, time);
+    return testSuiteResult;
+  }
 
-		NodeList testCases = root.getChildNodes();
-		for (int i = 0; i < testCases.getLength(); i++) {
-			Element node = (Element) testCases.item(i);
-			String testName = node.getAttribute("name");
-			String classname = node.getAttribute("classname");
-			double testTime = Double.parseDouble(root.getAttribute("time"));
-			JUnitTestCase testCase = new JUnitTestCase(testName, classname, testTime);
-			suite.addTestCase(testCase);
+  @Override
+  public JUnitTestSuite parseJUnitTestSuiteResult(String xml) {
+    Element root = parse(xml).getDocumentElement();
+    int errors = Integer.parseInt(root.getAttribute("errors"));
+    int failures = Integer.parseInt(root.getAttribute("failures"));
+    String hostname = root.getAttribute("hostname");
+    String name = root.getAttribute("name");
+    int tests = Integer.parseInt(root.getAttribute("tests"));
+    double time = Double.parseDouble(root.getAttribute("time"));
+    NodeList testCases = root.getChildNodes();
+    int cases = testCases.getLength();
+    JUnitTestSuite suite = new JUnitTestSuite(prettyPrintXml(xml), errors, failures, hostname, name, cases, tests, time);
+    for (int i = 0; i < testCases.getLength(); i++) {
+      Element node = (Element) testCases.item(i);
+      String testName = node.getAttribute("name");
+      String classname = node.getAttribute("classname");
+      double testTime = Double.parseDouble(root.getAttribute("time"));
+      int testCaseTests = Integer.parseInt(node.getAttribute("tests"));
+      int testsSuccess = Integer.parseInt(node.getAttribute("success"));
+      int testsFail = Integer.parseInt(node.getAttribute("fail"));
 
-			NodeList failureNodes = node.getChildNodes();
-			for (int j = 0; j < failureNodes.getLength(); j++) {
-				Element failureNode = (Element) failureNodes.item(j);
-				String type = failureNode.getAttribute("type");
-				String message = failureNode.getAttribute("message");
-				String failureXml = toXml(failureNode);
-				testCase.addTestFailure(new JUnitTestFailure(type, message, failureXml));
-			}
-		}
+      JUnitTestCase testCase = new JUnitTestCase(testName, classname, testTime, testCaseTests, testsSuccess, testsFail);
+      suite.addTestCase(testCase);
 
-		return suite;
-	}
+      NodeList failureNodes = node.getElementsByTagName("failure");
+      for (int j = 0; j < failureNodes.getLength(); j++) {
+        Element failureNode = (Element) failureNodes.item(j);
+        String type = failureNode.getAttribute("type");
+        String message = failureNode.getAttribute("message");
+        String failureXml = toXml(failureNode);
+        testCase.addTestFailure(new JUnitTestFailure(type, message, failureXml));
+      }
+      NodeList coverageNodes = node.getElementsByTagName("coverage");
+      for (int j = 0; j < coverageNodes.getLength(); j++) {
+        Element coverageNode = (Element) coverageNodes.item(j);
+        String module = coverageNode.getAttribute("module");
+        NodeList coverageInfo = coverageNode.getChildNodes();
+        JUnitTestCoverage testCoverage = new JUnitTestCoverage(module);
+        testCase.addTestCoverage(testCoverage);
+        for (int k = 0; k < coverageInfo.getLength(); k++) {
+          Element coverageInfoNode = (Element) coverageInfo.item(k);
+          String type = coverageInfoNode.getTagName();
+          int count = Integer.parseInt(coverageInfoNode.getAttribute("count"));
+          String infoXml = toXml(coverageInfoNode);
+          testCoverage.addCoverageInfo(new JUnitTestCoverageInfo(type, count, infoXml));
+        }
+      }
+    }
 
-	protected String toXml(Node node) {
-		try {
-			TransformerFactory transFactory = TransformerFactory.newInstance();
-			Transformer transformer = transFactory.newTransformer();
-			StringWriter buffer = new StringWriter();
-			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-			transformer.transform(new DOMSource(node), new StreamResult(buffer));
-			return buffer.toString();
-		} catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-	}
+    return suite;
+  }
 
-	protected void initializeDocumentBuilder() {
-		if (documentBuilder == null) {
-			try {
-				DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-				factory.setNamespaceAware(true);
-				documentBuilder = factory.newDocumentBuilder();
-			} catch (Exception ex) {
-				throw new RuntimeException("Unable to construct JAXP DocumentBuilder, cause: " + ex.getMessage(), ex);
-			}
-		}
-	}
+  protected String toXml(Node node) {
+    try {
+      TransformerFactory transFactory = TransformerFactory.newInstance();
+      Transformer transformer = transFactory.newTransformer();
+      StringWriter buffer = new StringWriter();
+      transformer.transform(new DOMSource(node), new StreamResult(buffer));
+      return buffer.toString();
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
 
-	protected Document parse(String xml) {
-		initializeDocumentBuilder();
-		try {
-			return documentBuilder.parse(new InputSource(new StringReader(xml)));
-		} catch (Exception ex) {
-			throw new RuntimeException("Unable to parse test list XML, cause: " + ex.getMessage(), ex);
-		}
-	}
+  protected String prettyPrintXml(String xmlString) {
+    return prettyPrintXml(xmlString, 2, false);
+  }
+
+  protected String prettyPrintXml(String xmlString, int indent, boolean ignoreDeclaration) {
+    try {
+      InputSource src = new InputSource(new StringReader(xmlString));
+      Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(src);
+
+      TransformerFactory transformerFactory = TransformerFactory.newInstance();
+      transformerFactory.setAttribute("indent-number", indent);
+      Transformer transformer = transformerFactory.newTransformer();
+      transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, ignoreDeclaration ? "yes" : "no");
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+      StringWriter buffer = new StringWriter();
+      transformer.transform(new DOMSource(document), new StreamResult(buffer));
+      return buffer.toString();
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  protected void initializeDocumentBuilder() {
+    if (documentBuilder == null) {
+      try {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        documentBuilder = factory.newDocumentBuilder();
+      } catch (Exception ex) {
+        throw new RuntimeException("Unable to construct JAXP DocumentBuilder, cause: " + ex.getMessage(), ex);
+      }
+    }
+  }
+
+  protected Document parse(String xml) {
+    initializeDocumentBuilder();
+    try {
+      return documentBuilder.parse(new InputSource(new StringReader(xml)));
+    } catch (Exception ex) {
+      throw new RuntimeException("Unable to parse test list XML, cause: " + ex.getMessage(), ex);
+    }
+  }
 
 }

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestModule.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestModule.java
@@ -5,8 +5,8 @@ package com.marklogic.test.unit;
  */
 public class TestModule {
 
-	private String test;
-	private String suite;
+	private final String test;
+	private final String suite;
 
 	public TestModule(String test, String suite) {
 		this.test = test;

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestResult.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestResult.java
@@ -2,13 +2,13 @@ package com.marklogic.test.unit;
 
 /**
  * Captures the result for a running a single test. failureXml will be populated if the test failed. Does not yet
- * capture the number of successful assertions, just whether or not the test succeeded.
+ * capture the number of successful assertions, just whether the test succeeded.
  */
 public class TestResult {
 
-	private String name;
-	private double time;
-	private String failureXml;
+	private final String name;
+	private final double time;
+	private final String failureXml;
 
 	public TestResult(String name, double time, String failureXml) {
 		this.name = name;

--- a/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestSuiteResult.java
+++ b/marklogic-unit-test-client/src/main/java/com/marklogic/test/unit/TestSuiteResult.java
@@ -11,17 +11,19 @@ import java.util.List;
  */
 public class TestSuiteResult {
 
-	private String xml;
-	private String name;
-	private int total;
-	private int passed;
-	private int failed;
-	private double time;
+	private final String xml;
+	private final String name;
+	private final int total;
+	private final int passed;
+	private final int failed;
+	private final double time;
+  private final int cases;
 	private List<TestResult> testResults = new ArrayList<>();
 
-	public TestSuiteResult(String xml, String name, int total, int passed, int failed, double time) {
+	public TestSuiteResult(String xml, String name, int cases, int total, int passed, int failed, double time) {
 		this.xml = xml;
 		this.name = name;
+    this.cases = cases;
 		this.total = total;
 		this.passed = passed;
 		this.failed = failed;
@@ -68,4 +70,8 @@ public class TestSuiteResult {
 	public String getXml() {
 		return xml;
 	}
+
+  public int getCases() {
+    return cases;
+  }
 }

--- a/marklogic-unit-test-client/src/test/java/com/marklogic/test/unit/RunSuiteTest.java
+++ b/marklogic-unit-test-client/src/test/java/com/marklogic/test/unit/RunSuiteTest.java
@@ -24,4 +24,23 @@ public class RunSuiteTest {
       databaseClient.release();
     }
   }
+
+  @Test
+  public void testWithCoverage() {
+    DatabaseClient databaseClient = DatabaseClientFactory.newClient("localhost", 8008,
+      new DatabaseClientFactory.DigestAuthContext("admin", "admin"));
+
+    try {
+      List<JUnitTestSuite> suites = new TestManager(databaseClient).runAllSuites(true, true, true);
+      DefaultJUnitTestReporter reporter = new DefaultJUnitTestReporter();
+
+      String testReport = reporter.reportOnJUnitTestSuites(suites);
+      System.out.println(testReport);
+      String coverageReport = reporter.reportOnJUnitTestSuitesCoverage(suites);
+      System.out.println(coverageReport);
+    }
+    finally {
+      databaseClient.release();
+    }
+  }
 }

--- a/marklogic-unit-test-modules/src/main/ml-modules/services/marklogic-unit-test.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/services/marklogic-unit-test.xqy
@@ -4,6 +4,8 @@ module namespace resource = "http://marklogic.com/rest-api/resource/marklogic-un
 
 import module namespace test = "http://marklogic.com/test" at "/test/test-controller.xqy";
 
+declare variable $TRACE-ID as xs:string := "UNIT-TEST";
+
 declare function get(
 	$context as map:map,
 	$params as map:map
@@ -36,7 +38,11 @@ declare private function run($params as map:map)
 	let $run-teardown as xs:boolean := map:get($params, "runteardown") eq "true"
 	let $format as xs:string := (map:get($params, "format"), "xml")[1]
 	let $calculate-coverage as xs:boolean := map:get($params, "calculatecoverage") eq "true"
-	return
+	return (
+		if (xdmp:trace-enabled($TRACE-ID))
+    then xdmp:trace($TRACE-ID,
+      fn:concat("RUN suite::", $suite,"::tests::", fn:string-join($tests,","), "::format::", $format, "::calculate-coverage::", $calculate-coverage))
+    else (),
 		if ($suite) then
 			let $result := test:run-suite($suite, $tests, $run-suite-teardown, $run-teardown, $calculate-coverage)
 			return
@@ -45,4 +51,5 @@ declare private function run($params as map:map)
 				else
 					$result
 		else ()
+  )
 };


### PR DESCRIPTION
format junit is modified so it will return nr otf tests, success and fails per testcase.
Also returns coverage info per testcase

Example:
```
<testsuite errors="0" failures="0" hostname="localhost" name="contexts/cds/components/security/test-suite" tests="18" time="8.193104" timestamp="2023-05-09T12:38:10.945312+02:00">
    <testcase classname="test-authenticate.xqy" name="test-authenticate.xqy" time="0.074011" tests="10" succes="10" fail="0">
        <coverage module="/contexts/cds/components/common/lib/config.xqy">
            <wanted count="232">38 76 117 143 162 163 176 177 178 191 192 205 206 207 220 221 234 235 236 237 238 251 252 265 281 283 284 286 288 289 291 292 309 324 339 353 366 379 392 405 418 431 444 457 470 483 501 514 516 517 531 544 557 570 582 583 584 586 596 598 599 600 612 623 634 645 656 671 673 675 679 681 684 686 687 705 706 708 710 712 713 719 721 722 740 741 755 756 757 758 772 774 775 790 791 792 794 795 797 799 800 802 804 819 821 822 834 835 849 852 853 866 868 870 872 873 875 878 880 882 884 885 886 887 888 889 890 911 912 915 916 918 919 920 924 925 927 930 932 934 937 938 940 943 945 947 948 950 951 956 958 960 962 963 969 971 972 973 1006 1007 1008 1010 1037 1038 1039 1041 1043 1045 1048 1050 1052 1053 1055 1057 1078 1080 1081 1095 1096 1098 1100 1101 1103 1107 1108 1110 1114 1115 1117 1119 1121 1122 1124 1125 1126 1127 1139 1154 1156 1158 1159 1160 1161 1162 1164 1165 1166 1179 1180 1182 1185 1187 1199 1211 1213 1215 1227 1228 1230 1231 1232 1233 1234 1235 1247 1248 1250 1251 1252 1253 1254 1255</wanted>
            <covered count="0"/>
            <missing count="232">38 76 117 143 162 163 176 177 178 191 192 205 206 207 220 221 234 235 236 237 238 251 252 265 281 283 284 286 288 289 291 292 309 324 339 353 366 379 392 405 418 431 444 457 470 483 501 514 516 517 531 544 557 570 582 583 584 586 596 598 599 600 612 623 634 645 656 671 673 675 679 681 684 686 687 705 706 708 710 712 713 719 721 722 740 741 755 756 757 758 772 774 775 790 791 792 794 795 797 799 800 802 804 819 821 822 834 835 849 852 853 866 868 870 872 873 875 878 880 882 884 885 886 887 888 889 890 911 912 915 916 918 919 920 924 925 927 930 932 934 937 938 940 943 945 947 948 950 951 956 958 960 962 963 969 971 972 973 1006 1007 1008 1010 1037 1038 1039 1041 1043 1045 1048 1050 1052 1053 1055 1057 1078 1080 1081 1095 1096 1098 1100 1101 1103 1107 1108 1110 1114 1115 1117 1119 1121 1122 1124 1125 1126 1127 1139 1154 1156 1158 1159 1160 1161 1162 1164 1165 1166 1179 1180 1182 1185 1187 1199 1211 1213 1215 1227 1228 1230 1231 1232 1233 1234 1235 1247 1248 1250 1251 1252 1253 1254 1255</missing>
        </coverage>
...
```