### PR TITLE
DEVEXP-525 Adding docs on running tests

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,9 +115,34 @@ The above code will invoke the `lookupTerm` function that we wish to test with a
 application's thesaurus. Each `assertEqual` function in the test library - along with every other assertion function - 
 will return a success or failure. The test then returns an array of these successes and failures.
 
+## Configuring a connection to MarkLogic
+
+In order to run the test we've written, the test must be loaded into a modules database in MarkLogic. Both loading and
+running the test requires connecting to a MarkLogic App Server. ml-gradle supports both of these tasks, but a 
+connection must be configured so that ml-gradle knows which App Server to connect to and how to authenticate. 
+
+By default, ml-gradle will use either the App Server port defined by the `mlTestRestPort` property if set, or else it
+will use the `mlRestPort` property. It will also use the 
+[REST API server connection properties](https://github.com/marklogic/ml-gradle/wiki/Property-reference#rest-api-server-connection-properties)
+for controlling how ml-gradle authenticates with the App Server. 
+
+In the case of our example project, the following properties in `gradle.properties` are used to configure a connection
+for loading and running tests:
+
+```
+mlHost=localhost
+mlRestPort=8024
+mlUsername=admin
+mlPassword=this value will be set in gradle-local.properties
+```
+
+For more information on configuring the connection, please see this
+[example project in ml-gradle](https://github.com/marklogic/ml-gradle/tree/master/examples/unit-test-project).
+
 ## Loading tests
 
-Now that we've written a test, we need to load it into our application's modules database so that it can be run.
+Now that we've written a test and configured a connection to MarkLogic, we are ready to load the test into our 
+application's modules database.
 ml-gradle offers a variety of tasks to accomplish this with `mlLoadModules` being the simplest one. However, having to 
 execute this task every time a test module is updated slows down the development cycle. To address this, ml-gradle 
 provides support for 

--- a/docs/loading-test-data.md
+++ b/docs/loading-test-data.md
@@ -4,4 +4,39 @@ title: Loading test data
 nav_order: 5
 ---
 
-Will do this via DEVEXP-528.
+marklogic-unit-test includes a simple mechanism for loading test data specific to a test suite. Doing so is useful when 
+a test or suite requires a set of documents to exist, and those documents may not apply to any other suite. 
+
+To use this feature, begin by creating a folder named "test-data" within a test suite directory. Each file stored in the
+"test-data" directory can then be loaded via marklogic-unit-test by specifying the name of the file.
+
+For example, if a test suite's "test data" directory contains a file named `sample-doc.json`, the following could be 
+added to either a `suiteSetup.sjs` or `setup.js` module for the test suite to load the file as a new document:
+
+```
+const test = require("/test/test-helper.xqy");
+test.loadTestFile(
+  "sample-doc.json", xdmp.database(), "/sample-doc.json",
+  [xdmp.permission("rest-reader", "read", "element"), xdmp.permission("rest-writer", "update", "element")],
+  ["collection1", "collection2"]
+);
+```
+
+The same can be accomplished in XQuery via a `setup.xqy` module - this example also shows that the fourth and fifth
+arguments for permissions and collections are optional:
+
+```
+import module namespace test = "http://marklogic.com/test" at "/test/test-helper.xqy";
+test:load-test-file("sample-doc.json", xdmp:database(), "/sample-doc.json")
+```
+
+The above examples can also be implemented in either `suiteSetup.sjs` or `suite-setup.xqy` if desired - see the 
+[guide on writing tests](writing-tests.md) for more information on setup and teardown modules.
+
+You can also use a teardown module to delete the data that was loaded. However, leaving data in place after a test 
+concludes is often helpful for both manually verifying what it's in the database and for debugging test failures. 
+Instead of deleting data after a test runs, consider deleting data before a test runs to ensure the database is in a 
+"clean" state. For example, a suite setup module can be used to delete all documents in a database (perhaps excluding a 
+collection of documents that are read-only and won't be impacted by any tests), and a setup module can insert certain
+documents that may be modified by tests.
+

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -4,4 +4,88 @@ title: Running tests
 nav_order: 4
 ---
 
-Will do this via DEVEXP-525.
+Tests written using marklogic-unit-test can be run in several ways, each of which is described below. 
+
+## Using the web application
+
+Once you have deployed your application along with the marklogic-unit-test modules, as described in the 
+[Getting started guide](getting-started.md), you will be able to access a custom endpoint via any MarkLogic HTTP 
+App Server associated with the modules database containing your application modules. The path of that endpoint is 
+`/test/default.xqy`. For example, since the App Server in the [Getting started guide](getting-started.md) listens on 
+port 8024, the endpoint would be accessible at <http://localhost:8024/test/default.xqy>.
+
+The web application at this custom endpoint provides a functional, albeit antiquated-looking, interface for running
+one or more tests and/or suites at a time. Use the checkboxes under "Run" and "Run All Tests" to select which tests
+and suites you would like to run. Click the "Run Tests" button in the upper right-hand corner to run the selected
+tests. Any failed test will display a message capturing the assertion failure. 
+
+## Using Gradle 
+
+The [ml-gradle plugin for Gradle](https://github.com/marklogic/ml-gradle) provides an `mlUnitTest` task for running 
+all of your marklogic-unit-test tests. As noted in the [Getting started guide](getting-started.md), you will need to 
+include the following block at the top of your `build.gradle` file to ensure this task can run successfully:
+
+```
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "com.marklogic:marklogic-unit-test-client:1.3.0"
+  }
+}
+```
+
+You can then run the task:
+
+    ./gradlew mlUnitTest
+
+The output of this task will capture how many tests passed and how many failed. A failure message will be displayed for
+each test that fails. 
+
+Please see 
+[the ml-gradle example project for marklogic-unit-test](https://github.com/marklogic/ml-gradle/tree/master/examples/unit-test-project)
+for more information on how tests are run, along with more information on how to configure the connection to a MarkLogic
+App Server.
+
+## Using JUnit5
+
+The [marklogic-junit5 library](https://github.com/marklogic-community/marklogic-unit-test/tree/master/marklogic-junit5) 
+within this project provides support for testing REST endpoints in MarkLogic. It also supports running your 
+marklogic-unit-test tests as part of a JUnit test suite. This allows for a single test run to execute and report on 
+all of your tests - both your JUnit5 tests that invoke REST endpoints in MarkLogic and each of your marklogic-unit-test
+test modules.
+
+For further information, see 
+[the marklogic-junit5 example project](https://github.com/marklogic-community/marklogic-unit-test/tree/master/marklogic-junit5/examples/simple-ml-gradle)
+that describes the configuration necessary.
+
+## Using the marklogic-unit-test REST extension
+
+The marklogic-unit-test library includes a REST extension available at `/v1/resources/marklogic-unit-test`. This 
+extension is used to both list and run tests. You can therefore use this to integrate the execution of 
+marklogic-unit-test tests into any testing framework that can invoke HTTP endpoints. 
+
+To list tests, send a GET request to the extension endpoint. You will receive an XML response similar to the one shown
+below:
+
+```
+<test:tests xmlns:test="http://marklogic.com/test">
+  <test:suite path="thesaurus">
+    <test:tests>
+      <test:test path="simple-test.sjs"/>
+    </test:tests>
+  </test:suite>
+  <test:formats>
+    <test:format path="j-unit.xsl"/>
+  </test:formats>
+</test:tests>
+```
+
+To run a suite of tests, send a POST request to the extension with the following querystring parameters defined:
+
+- `rs:suite` = required; the name of the test suite to run.
+- `rs:tests` = optional; comma-separated list of test names to run within a suite.
+- `rs:runsuiteteardown` = optional, defaults to true; if false, skip running the teardown module for the suite.
+- `rs:runteardown` = optional, defaults to true; if false, skip running the teardown module after each test.
+- `rs:format` = optional, defaults to "xml"; the format to use for returning results; can specify "junit" instead.


### PR DESCRIPTION
I realized while doing this that we'll need a separate page soon for the JUnit 5 support. We have docs on that in the form of a README and an example project, but it'd be better to fold that into this user guide. That's outside the scope of this PR. 

I tossed in the stuff for loading data too, as that ended up being trivial to write. 