### PR TITLE
DEVEXP-552: test:assert-true passes for non-true values

### DIFF
--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-true.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-true.xqy
@@ -25,4 +25,11 @@ test:assert-throws-error-with-message(
   },
   "ASSERT-TRUE-FAILED",
   "Failure message; Condition was not true."
+),
+
+test:assert-throws-error(
+  function() {
+    test:assert-true(())
+  },
+  "ASSERT-TRUE-FAILED"
 )

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/JavaScript Modules/assertTrue.mjs
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/JavaScript Modules/assertTrue.mjs
@@ -1,0 +1,46 @@
+const test = require("/test/test-helper.xqy");
+
+const list = fn.head(xdmp.apply(xdmp.function(fn.QName("http://marklogic.com/test", "list"), "/test/test-controller.xqy")));
+
+function assertThrowsError(f, errorName)
+{
+  try {
+    f();
+    test.fail('Function did not fail');
+  }
+  catch (e) {
+    test.success();
+    xdmp.log(e, 'error');
+    let actual = e.stack.substr(0, e.stack.indexOf(" at "))
+    if (!e.stack.includes(errorName)) {
+      test.fail(`Function failed, but did not contain expected error [${errorName}] actual: [${actual}]`);
+    }
+  }
+}
+
+const assertions = [];
+assertions.push(
+  test.assertTrue(true),
+
+  assertThrowsError(
+    function() {
+      test.assertTrue(false);
+    },
+    "ASSERT-TRUE-FAILED"
+  ),
+
+  assertThrowsError(
+    function() {
+      test.assertTrue(null);
+    },
+    "ASSERT-TRUE-FAILED"
+  ),
+
+  assertThrowsError(
+    function() {
+      test.assertTrue(undefined);
+    },
+    "ASSERT-TRUE-FAILED"
+  )
+);
+assertions;

--- a/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -737,7 +737,9 @@ declare function test:assert-true($conditions as xs:boolean*) {
 };
 
 declare function test:assert-true($conditions as xs:boolean*, $message as xs:string?) {
-  if (fn:false() = $conditions) then
+  if (fn:empty($conditions)) then
+      fn:error(xs:QName("ASSERT-TRUE-FAILED"), fn:string-join(($message, "Condition was not true."), "; ") , $conditions)
+  else if (fn:false() = $conditions) then
     fn:error(xs:QName("ASSERT-TRUE-FAILED"), fn:string-join(($message, "Condition was not true."), "; ") , $conditions)
   else
     test:success()


### PR DESCRIPTION
I added a new JavaScript test suite file. Perhaps this isn't strictly necessary since it's calling the same XQY assertion functions, but it covers the scenarios in the story.