### PR TITLE
DEVEXP-551: Assert JSON arrays are the same with test:assert-same-values

### DIFF
--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-equal-json.sjs
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-equal-json.sjs
@@ -63,7 +63,6 @@ function assertThrowsErrorWithMessage(f, errorName, errorMessage)
     test.fail('Function did not fail');
   }
   catch (e) {
-    test.success();
     xdmp.log(e, 'info');
     let actual = e.stack.substr(0, e.stack.indexOf(" at "))
     if (!e.stack.includes(errorName)) {
@@ -72,6 +71,7 @@ function assertThrowsErrorWithMessage(f, errorName, errorMessage)
     if (!e.stack.includes(errorMessage)) {
       test.fail(`Function failed, but did not contain expected message [${errorMessage}] actual [${actual}]`);
     }
+    return test.success();
   }
 }
 

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-same-values-json-array.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-same-values-json-array.xqy
@@ -1,0 +1,82 @@
+xquery version "1.0-ml";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
+
+((
+  test:assert-same-values(
+    array-node { },
+    array-node { },
+    "Two empty arrays, should be equal."
+  )
+,
+  test:assert-same-values(
+    array-node { 1 },
+    array-node { 1 },
+    "Two arrays with the same single elements, should be equal."
+  )
+,
+  test:assert-same-values(
+    array-node { 1, 2, 4, 3 },
+    array-node { 3, 4, 1, 2 },
+    "Two arrays with the same elements, in a different order, should be equal."
+  )
+,
+  test:assert-same-values(
+    array-node { 1, 2, 4, 3, 4 },
+    array-node { 3, 4, 1, 4, 2 },
+    "Two arrays with the same elements (including duplicates), in a different order, should be equal."
+  )
+,
+  test:assert-same-values(
+    array-node { "A", "F", "BG", "E", "BC" },
+    array-node { "BC", "F", "A", "E", "BG" },
+    "Two arrays with the same string elements, in a different order, should be equal."
+  )
+,
+  test:assert-throws-error-with-message(
+    function() {
+      test:assert-same-values(
+        array-node { 1, 2, 4, 5 },
+        array-node { 1, 2, 4, 5, 5 },
+        "An array with a duplicate should not equal an array without that duplicate."
+      )
+    },
+    "ASSERT-EQUAL-FAILED",
+    "An array with a duplicate should not equal an array without that duplicate.; expected: (1, 2, 4, ...) actual: (1, 2, 4, ...)"
+  )
+,
+  test:assert-throws-error-with-message(
+    function() {
+      test:assert-same-values(
+        array-node { 1, 2, 4 },
+        array-node { 1, 2, 4, 5 },
+        "A longer Actual array should not equal a shorter Expected array."
+      )
+    },
+    "ASSERT-EQUAL-FAILED",
+    "A longer Actual array should not equal a shorter Expected array.; expected: (1, 2, 4) actual: (1, 2, 4, ...)"
+  )
+,
+  test:assert-throws-error-with-message(
+    function() {
+      test:assert-same-values(
+        array-node { 1, 2, 4 },
+        array-node { 1, 2 },
+        "A shorter Actual array should not equal a longer Expected array."
+      )
+    },
+    "ASSERT-EQUAL-FAILED",
+    "A shorter Actual array should not equal a longer Expected array.; expected: (1, 2, 4) actual: (1, 2)"
+  )
+,
+  test:assert-throws-error-with-message(
+    function() {
+      test:assert-same-values(
+        array-node { 1, 2, 4 },
+        array-node { 1, 2, object-node {"A": "4"} },
+        "This actually causes an exception since the items are not comparable."
+      )
+    },
+    "err:XPTY0004",
+    "Items not comparable"
+  )
+))

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-same-values-sequences.xqy
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assert-same-values-sequences.xqy
@@ -1,0 +1,35 @@
+xquery version "1.0-ml";
+import module namespace test="http://marklogic.com/test" at "/test/test-helper.xqy";
+
+((
+  test:assert-same-values(
+    (),
+    (),
+    "Two empty sequences, should be equal."
+  ),
+  test:assert-same-values(
+    (1),
+    (1),
+    "Two sequences with a single matching atomic element, should be equal."
+  ),
+  test:assert-same-values(
+    (1, 2, 4, 3),
+    (3, 4, 1, 2),
+    "Two sequences with a multiple matching atomic elements, should be equal."
+  ),
+  test:assert-same-values(
+    (1, 2, 4, 3, 4),
+    (3, 4, 1, 4, 2),
+    "Two sequences with a multiple matching atomic elements, should be equal."
+  ),
+  test:assert-same-values(
+    (<A/>),
+    (<A/>),
+    "Two sequences with the same single XML element, should be equal."
+  ),
+  test:assert-same-values(
+    (<A>a</A>, <B>b</B>, <D>d</D>, <C>c</C>),
+    (<C>c</C>, <D>d</D>, <A>a</A>, <B>b</B>),
+    "Two sequences with the same multiple XML elements, should be equal."
+  )
+))

--- a/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assertSameValuesJsonArray.sjs
+++ b/marklogic-unit-test-client/src/test/ml-modules/root/test/suites/Assertions/assertSameValuesJsonArray.sjs
@@ -1,0 +1,63 @@
+const test = require('/test/test-helper.xqy');
+
+function assertThrowsErrorWithMessage(f, errorName, errorMessage)
+{
+  try {
+    f();
+    test.fail('Function did not fail');
+  }
+  catch (e) {
+    xdmp.log(e, 'info');
+    let actual = e.stack.substr(0, e.stack.indexOf(" at "))
+    if (!e.stack.includes(errorName)) {
+      test.fail(`Function failed, but did not contain expected error [${errorName}] actual: [${actual}]`);
+    }
+    if (!e.stack.includes(errorMessage)) {
+      test.fail(`Function failed, but did not contain expected message [${errorMessage}] actual [${actual}]`);
+    }
+    return test.success();
+  }
+}
+
+[
+  test.assertSameValues([], []),
+  test.assertSameValues([1], [1]),
+  test.assertSameValues([1, 2, 4, 3], [3, 4, 1, 2]),
+  test.assertSameValues([1, 2, 4, 3, 4], [3, 4, 1, 4, 2]),
+  test.assertSameValues(["A", "F", "BG", "E", "BC"], ["BC", "F", "A", "E", "BG"]),
+  assertThrowsErrorWithMessage(
+    function() {
+      test.assertSameValues([1, 2, 4, 5], [1, 2, 4, 5, 5], "An array with a duplicate should not equal an array without that duplicate.")
+    },
+    "ASSERT-EQUAL-FAILED",
+    "An array with a duplicate should not equal an array without that duplicate.; expected: (1, 2, 4, ...) actual: (1, 2, 4, ...)"
+  ),
+  assertThrowsErrorWithMessage(
+    function() {
+      test.assertSameValues([1, 2, 4], [1, 2, 4, 5], "A longer Actual array should not equal a shorter Expected array.")
+    },
+    "ASSERT-EQUAL-FAILED",
+    "A longer Actual array should not equal a shorter Expected array.; expected: (1, 2, 4) actual: (1, 2, 4, ...)"
+  ),
+  assertThrowsErrorWithMessage(
+    function() {
+      test.assertSameValues([1, 2, 4], [1, 2], "A shorter Actual array should not equal a longer Expected array.")
+    },
+    "ASSERT-EQUAL-FAILED",
+    "A shorter Actual array should not equal a longer Expected array.; expected: (1, 2, 4) actual: (1, 2)"
+  ),
+  assertThrowsErrorWithMessage(
+    function() {
+      test.assertSameValues([1, 2, 4], [1, 2, "S"], "This actually causes an exception since the items are not comparable.")
+    },
+    "err:XPTY0004",
+    "Items not comparable"
+  ),
+  assertThrowsErrorWithMessage(
+    function() {
+      test.assertSameValues([{"A": "a"}, {"B": "b"}], [{"B": "b"}, {"A": "a"}], "This actually causes an exception since we do not handle JSON objects and the items are not comparable.")
+    },
+    "err:XPTY0004",
+    "Items not comparable"
+  )
+]


### PR DESCRIPTION
Marked as draft because I don't love this implementation, but it might be the one we should go with for now.
In the meantime, I'll spend a bit of time trying something different before removing the draft tag and merging.